### PR TITLE
Add configurable hotkeys and separate toggle/mode controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,35 @@ interpreter-v2 --debug
 
 ## Controls
 
+Default hotkeys (configurable in `config.yml`):
+
 | Key | Action |
 |-----|--------|
-| `m` | Cycle overlay mode: off → banner → inplace |
+| `Space` | Toggle overlay on/off |
+| `m` | Switch mode: banner ↔ inplace |
 | `-` | Decrease font size |
 | `=` | Increase font size |
 | `q` | Quit |
 
 In banner mode, you can drag the overlay to reposition it.
+
+### Custom Hotkeys
+
+You can customize hotkeys in `config.yml`:
+
+```yaml
+hotkeys:
+  toggle_overlay: "space"   # Toggle overlay on/off
+  switch_mode: "m"          # Switch between banner/inplace
+  increase_font: "="        # Increase font size
+  decrease_font: "-"        # Decrease font size
+  quit: "q"                 # Quit application
+```
+
+Supported key values:
+- Single characters: `a`-`z`, `0`-`9`, `` ` ``, `-`, `=`, etc.
+- Function keys: `f1`-`f12`
+- Special keys: `space`, `escape`, `enter`, `tab`, `backspace`, `delete`, `insert`, `home`, `end`, `page_up`, `page_down`, `up`, `down`, `left`, `right`
 
 ## Overlay Modes
 

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -15,15 +15,25 @@ class Config:
 
     DEFAULT_WINDOW_TITLE = "Snes9x"
 
+    # Default hotkeys
+    DEFAULT_HOTKEYS = {
+        "toggle_overlay": "space",
+        "switch_mode": "m",
+        "increase_font": "=",
+        "decrease_font": "-",
+        "quit": "q",
+    }
+
     def __init__(
         self,
         window_title: str = "Snes9x",
         refresh_rate: float = 0.5,
         ocr_confidence: float = 0.6,
         overlay_mode: str = "banner",
-        font_size: int = 40,
+        font_size: int = 26,
         font_color: str = "#FFFFFF",
         background_color: str = "#404040",
+        hotkeys: dict | None = None,
         config_path: str | None = None,
     ):
         self.window_title = window_title
@@ -33,6 +43,7 @@ class Config:
         self.font_size = font_size
         self.font_color = font_color
         self.background_color = background_color
+        self.hotkeys = hotkeys if hotkeys is not None else self.DEFAULT_HOTKEYS.copy()
         self.config_path = config_path
 
     @classmethod
@@ -63,14 +74,21 @@ class Config:
             config_path = str(Path(config_path).resolve())
             with open(config_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
+
+            # Load hotkeys with defaults for any missing keys
+            hotkeys_data = data.get("hotkeys", {})
+            hotkeys = cls.DEFAULT_HOTKEYS.copy()
+            hotkeys.update(hotkeys_data)
+
             return cls(
                 window_title=data.get("window_title", cls.DEFAULT_WINDOW_TITLE),
                 refresh_rate=float(data.get("refresh_rate", 0.5)),
                 ocr_confidence=float(data.get("ocr_confidence", 0.6)),
                 overlay_mode=data.get("overlay_mode", "banner"),
-                font_size=int(data.get("font_size", 40)),
+                font_size=int(data.get("font_size", 26)),
                 font_color=data.get("font_color", "#FFFFFF"),
                 background_color=data.get("background_color", "#404040"),
+                hotkeys=hotkeys,
                 config_path=config_path,
             )
 
@@ -108,9 +126,19 @@ ocr_confidence: 0.6
 overlay_mode: banner
 
 # Subtitle appearance
-font_size: 40
+font_size: 26
 font_color: "#FFFFFF"
 background_color: "#404040"
+
+# Hotkeys - single characters or special key names
+# Special keys: f1-f12, escape, space, enter, tab, backspace, delete,
+#               insert, home, end, page_up, page_down, up, down, left, right
+hotkeys:
+  toggle_overlay: "space"
+  switch_mode: "m"
+  increase_font: "="
+  decrease_font: "-"
+  quit: "q"
 """
         with open(config_path, "w", encoding="utf-8") as f:
             f.write(default_config)

--- a/src/interpreter/input/linux.py
+++ b/src/interpreter/input/linux.py
@@ -124,7 +124,11 @@ class KeyboardListener:
                         pass  # Don't crash on callback errors
 
     def _keysym_to_char(self, keysym: int) -> Optional[str]:
-        """Convert X11 keysym to character string."""
+        """Convert X11 keysym to character string.
+
+        Returns either a single character (e.g., 'm', '`') or a special key name
+        (e.g., 'f1', 'escape', 'space') to match pynput's naming convention.
+        """
         # Handle common ASCII characters
         if 0x20 <= keysym <= 0x7e:
             return chr(keysym)
@@ -135,13 +139,44 @@ class KeyboardListener:
             # Single character names are the character itself
             if len(keysym_name) == 1:
                 return keysym_name
-            # Map special key names
-            special_keys = {
+
+            # Map X11 keysym names to pynput-compatible names
+            name_lower = keysym_name.lower()
+
+            # Character keys with multi-char X11 names
+            char_keys = {
                 'minus': '-',
                 'equal': '=',
                 'plus': '+',
+                'grave': '`',
+                'quoteleft': '`',
             }
-            return special_keys.get(keysym_name.lower())
+            if name_lower in char_keys:
+                return char_keys[name_lower]
+
+            # Special keys - return pynput-compatible names
+            special_keys = {
+                'escape': 'escape',
+                'return': 'enter',
+                'space': 'space',
+                'tab': 'tab',
+                'backspace': 'backspace',
+                'delete': 'delete',
+                'insert': 'insert',
+                'home': 'home',
+                'end': 'end',
+                'prior': 'page_up',
+                'next': 'page_down',
+                'up': 'up',
+                'down': 'down',
+                'left': 'left',
+                'right': 'right',
+                'f1': 'f1', 'f2': 'f2', 'f3': 'f3', 'f4': 'f4',
+                'f5': 'f5', 'f6': 'f6', 'f7': 'f7', 'f8': 'f8',
+                'f9': 'f9', 'f10': 'f10', 'f11': 'f11', 'f12': 'f12',
+            }
+            if name_lower in special_keys:
+                return special_keys[name_lower]
 
         return None
 

--- a/src/interpreter/input/macos.py
+++ b/src/interpreter/input/macos.py
@@ -22,7 +22,11 @@ class KeyboardListener:
         """Handle key press events from pynput."""
         try:
             if hasattr(key, 'char') and key.char:
+                # Regular character key (e.g., 'm', 'q', '`')
                 self._on_press(key.char)
+            elif hasattr(key, 'name') and key.name:
+                # Special key (e.g., 'f1', 'escape', 'space')
+                self._on_press(key.name)
         except AttributeError:
             pass
 

--- a/src/interpreter/input/windows.py
+++ b/src/interpreter/input/windows.py
@@ -22,7 +22,11 @@ class KeyboardListener:
         """Handle key press events from pynput."""
         try:
             if hasattr(key, 'char') and key.char:
+                # Regular character key (e.g., 'm', 'q', '`')
                 self._on_press(key.char)
+            elif hasattr(key, 'name') and key.name:
+                # Special key (e.g., 'f1', 'escape', 'space')
+                self._on_press(key.name)
         except AttributeError:
             pass
 


### PR DESCRIPTION
## Summary

- Separate hotkey controls: `space` toggles overlay on/off, `m` switches between banner/inplace modes
- All hotkeys are now configurable via `config.yml`
- Support for special keys (f1-f12, escape, space, enter, arrows, etc.)
- Updated input modules for Windows, macOS, and Linux
- Changed default font size from 40 to 26
- Added font_size to startup log

## Configuration

```yaml
hotkeys:
  toggle_overlay: "space"
  switch_mode: "m"
  increase_font: "="
  decrease_font: "-"
  quit: "q"
```

## Test plan

- [ ] Test toggle overlay with space key
- [ ] Test switch mode with m key (only works when overlay visible)
- [ ] Test custom hotkey configuration
- [ ] Test special keys (e.g., f1, escape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)