### PR TITLE
Fix Windows capture using partial title instead of actual title

### DIFF
--- a/src/interpreter/capture/__init__.py
+++ b/src/interpreter/capture/__init__.py
@@ -65,6 +65,7 @@ class WindowCapture:
         """
         self.window_title = window_title
         self._window_id: Optional[int] = None
+        self._actual_title: Optional[str] = None  # Full window title (for Windows capture)
         self._last_bounds: Optional[dict] = None
         self._stream: Optional[CaptureStream] = None
         self._capture_interval = capture_interval
@@ -78,6 +79,7 @@ class WindowCapture:
         window = find_window_by_title(self.window_title)
         if window:
             self._window_id = window["id"]
+            self._actual_title = window["title"]  # Store actual title for Windows capture
             self._last_bounds = window["bounds"]
             return True
         return False
@@ -169,8 +171,8 @@ class WindowCapture:
 
         # Create platform-specific stream
         if _system == "Windows":
-            # Windows uses window title for capture
-            self._stream = CaptureStream(self.window_title)
+            # Windows uses exact window title for capture
+            self._stream = CaptureStream(self._actual_title)
         elif _system == "Linux":
             # Linux uses background thread with configurable interval
             self._stream = CaptureStream(self._window_id, self._capture_interval)


### PR DESCRIPTION
## Summary
The `WindowsCapture` library requires the exact window title, but we were passing the user's search substring (e.g., "snes") instead of the actual window title (e.g., "Snes9x 1.62.3 - game.sfc").

This caused the error:
```
Exception: Failed to find window: Failed to find a window with the name: snes
```

## Changes
- Store the actual window title when finding the window via partial match
- Pass the actual title (not the search term) to `WindowsCaptureStream`

## Test plan
- [x] Test with partial window title match (e.g., `--window "snes"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)