### PR TITLE
Install from PyPI instead of Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Offline screen translator for Japanese retro games. Captures text from any windo
 
 - Python 3.11+ (Python 3.14 not yet supported)
 - **Windows 10 version 1903+**, macOS, or Linux (X11/XWayland)
-- Git (Windows: install [Git for Windows](https://git-scm.com/download/win))
 
 ## Installation
 

--- a/install.ps1
+++ b/install.ps1
@@ -29,19 +29,19 @@ if (-not $uvPath) {
 }
 
 # Install or upgrade interpreter-v2
-Write-Host "[2/3] Installing interpreter-v2 from GitHub..." -ForegroundColor Yellow
+Write-Host "[2/3] Installing interpreter-v2 from PyPI..." -ForegroundColor Yellow
 Write-Host "     (this may take a minute on first install)" -ForegroundColor Gray
-# Use Python 3.13 explicitly - onnxruntime doesn't have wheels for 3.14 yet
+# Use Python 3.12 explicitly - onnxruntime doesn't have wheels for 3.14 yet
 # Temporarily allow errors so uv's progress output (on stderr) doesn't stop the script
 $ErrorActionPreference = 'Continue'
-uv tool install --upgrade --python 3.13 "git+https://github.com/bquenin/interpreter@main"
+uv tool install --upgrade --python 3.12 interpreter-v2
 $installExitCode = $LASTEXITCODE
 $ErrorActionPreference = 'Stop'
 if ($installExitCode -ne 0) {
     Write-Host ""
     Write-Host "Installation failed!" -ForegroundColor Red
     Write-Host "This may be due to missing dependencies. Try:" -ForegroundColor Yellow
-    Write-Host "  uv python install 3.13"
+    Write-Host "  uv python install 3.12"
     Write-Host "  Then run this installer again."
     exit 1
 }

--- a/install.sh
+++ b/install.sh
@@ -43,11 +43,10 @@ else
 fi
 
 # Install or upgrade interpreter-v2
-echo -e "${YELLOW}[2/${TOTAL_STEPS}] Installing interpreter-v2 from GitHub...${NC}"
+echo -e "${YELLOW}[2/${TOTAL_STEPS}] Installing interpreter-v2 from PyPI...${NC}"
 echo -e "${GRAY}     (this may take a minute on first install)${NC}"
-BRANCH="${INTERPRETER_BRANCH:-main}"
 # Use Python 3.12 - uv-managed Python includes tkinter, system Python 3.13+ often doesn't
-if ! uv tool install --upgrade --python 3.12 "git+https://github.com/bquenin/interpreter@${BRANCH}" 2>&1; then
+if ! uv tool install --upgrade --python 3.12 interpreter-v2 2>&1; then
     echo ""
     echo -e "${RED}Installation failed!${NC}"
     echo -e "${YELLOW}This may be due to missing dependencies. Try:${NC}"


### PR DESCRIPTION
## Summary

- Switch install scripts to use PyPI package instead of `git+` URL
- Removes Git as a requirement for Windows users
- Align Windows installer to Python 3.12 (same as macOS/Linux)
- Remove Git from README requirements

Fixes #143

## Test plan

- [x] Test Windows install - verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)