### PR TITLE
Use evdev for global hotkeys on Linux, enabling Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ sudo pacman -S gst-plugin-pipewire
 Without these packages, the application still works but can only capture X11/XWayland windows.
 
 **Known limitations:**
-- Global hotkeys (e.g., Space to toggle overlay) only work when an X11/XWayland window is focused. When a native Wayland window has focus, use the GUI button to toggle the overlay instead.
+- Global hotkeys on native Wayland require `input` group membership:
+  ```bash
+  sudo usermod -aG input $USER
+  ```
+  Then log out and back in. Without this, use the GUI button to toggle the overlay.
 - Inplace overlay mode only works correctly with **fullscreen** native Wayland windows. For windowed mode, use Banner overlay or capture via X11/XWayland instead. (Wayland's security model prevents applications from knowing window positions.)
 
 **Tip:** To capture a fullscreen Wayland window, put the game in fullscreen mode *before* starting the capture in Interpreter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ dependencies = [
     "nvidia-cudnn-cu12; sys_platform == 'win32' or sys_platform == 'linux'",
     # GUI
     "PySide6>=6.6.0",
-    # Global hotkeys - pynput for macOS/Windows, python-xlib for Linux
-    "pynput>=1.7.0; sys_platform != 'linux'",
+    # Global hotkeys
+    "pynput>=1.7.0",
     "pyobjc-framework-cocoa>=12.1; sys_platform == 'darwin'",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "interpreter-v2"
-version = "2.5.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "ctranslate2" },
@@ -277,7 +277,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pygobject", marker = "sys_platform == 'linux'" },
-    { name = "pynput", marker = "sys_platform != 'linux'" },
+    { name = "pynput" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
     { name = "pyside6" },
@@ -309,7 +309,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'", specifier = ">=0.0.9" },
     { name = "pygobject", marker = "sys_platform == 'linux'", specifier = ">=3.42.0" },
-    { name = "pynput", marker = "sys_platform != 'linux'", specifier = ">=1.7.0" },
+    { name = "pynput", specifier = ">=1.7.0" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'", specifier = ">=12.1" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'", specifier = ">=10.0" },
     { name = "pyside6", specifier = ">=6.6.0" },
@@ -567,11 +567,11 @@ name = "pynput"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "evdev", marker = "(platform_machine != 'aarch64' and 'linux' in sys_platform) or (sys_platform != 'linux' and 'linux' in sys_platform)" },
+    { name = "evdev", marker = "'linux' in sys_platform" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "python-xlib", marker = "(platform_machine != 'aarch64' and 'linux' in sys_platform) or (sys_platform != 'linux' and 'linux' in sys_platform)" },
-    { name = "six", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "python-xlib", marker = "'linux' in sys_platform" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Replace X11 RECORD extension with evdev for keyboard listening on Linux
- Enables global hotkeys on native Wayland windows (requires `input` group membership)
- macOS/Windows continue to use pynput unchanged

## Changes
- **keyboard.py**: Use evdev directly instead of X11 RECORD or pynput on Linux
- **pyproject.toml**: Add pynput unconditionally (still used on macOS/Windows)
- **install.sh**: Add Python dev headers step, print input group instructions on Wayland
- **README.md**: Update Wayland hotkey documentation with input group requirement

## Test plan
- [x] Test hotkeys on Wayland session (with user in `input` group)
- [x] Verify keyboard detection and keypress logging
- [x] Confirm graceful message if not in `input` group

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)