### PR TITLE
Fix Steam Deck/Arch Linux install by using evdev-binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,11 @@ dependencies = [
     "nvidia-cudnn-cu12; sys_platform == 'win32' or sys_platform == 'linux'",
     # GUI
     "PySide6>=6.6.0",
-    # Global hotkeys
-    "pynput>=1.7.0",
+    # Global hotkeys (macOS/Windows use pynput, Linux uses evdev directly)
+    "pynput>=1.7.0; sys_platform == 'darwin' or sys_platform == 'win32'",
     "pyobjc-framework-cocoa>=12.1; sys_platform == 'darwin'",
+    # Linux only - global hotkeys (evdev-binary provides pre-built wheels, no kernel headers needed)
+    "evdev-binary>=1.9.0; sys_platform == 'linux'",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/fe/a17c106a1f4061ce83f04d14bcedcfb2c38c7793ea56bfb906a6fadae8cb/evdev-1.9.2.tar.gz", hash = "sha256:5d3278892ce1f92a74d6bf888cc8525d9f68af85dbe336c95d1c87fb8f423069", size = 33301, upload-time = "2025-05-01T19:53:47.69Z" }
 
 [[package]]
+name = "evdev-binary"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/46/f76a9a451ce5435690e6d7e3381b493becef5790f6a37b28ca0af380fa1c/evdev_binary-1.9.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9717f88f4585daae3a674d8a390bf9603a05f778af5b61e75dbc5e504119f5e4", size = 111110, upload-time = "2025-05-01T19:54:09.799Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2d/25632fe8be94023e1e82ce50ea2c0af420b4540a67a325378947a8758e5a/evdev_binary-1.9.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9eb239d10e9b0160751523f3343f4264d8c207c7a08da68f8cc110f6c4e94ccc", size = 112132, upload-time = "2025-05-01T19:54:11.949Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/09/f5061fc73d3af808c43b2efb7f00e26483ac8308aab53d16085cd7d27002/evdev_binary-1.9.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7f9f221edc89bf2912c4eca60c65ce2cf2a0333ee242e0f9e8ca2922f5a20678", size = 111300, upload-time = "2025-05-01T19:54:13.474Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5c/f5efdf69fa14310c273ca975e63751ee5fc675321a0c910a76717cd7bd22/evdev_binary-1.9.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:594ea8bbabf0ac8f5e8ee469b31120cb65b1cafebac6aa65f55d7288c7133504", size = 112195, upload-time = "2025-05-01T19:54:14.864Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/6a4eeaae3293565f71d21a9a253c38c71087efb226ad17bf3a91b3efd519/evdev_binary-1.9.2-pp311-pypy311_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ffde86b061718c278cfce8d638dfb74a5c3decf0a82a390535ebc88697b66c9", size = 74887, upload-time = "2025-05-01T19:54:28.321Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -262,11 +274,12 @@ wheels = [
 
 [[package]]
 name = "interpreter-v2"
-version = "2.9.0"
+version = "2.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "ctranslate2" },
     { name = "dbus-python", marker = "sys_platform == 'linux'" },
+    { name = "evdev-binary", marker = "sys_platform == 'linux'" },
     { name = "meikiocr" },
     { name = "mss" },
     { name = "numpy" },
@@ -277,7 +290,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'" },
     { name = "pygobject", marker = "sys_platform == 'linux'" },
-    { name = "pynput" },
+    { name = "pynput", marker = "sys_platform == 'darwin' or sys_platform == 'win32'" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
     { name = "pyside6" },
@@ -299,6 +312,7 @@ dev = [
 requires-dist = [
     { name = "ctranslate2" },
     { name = "dbus-python", marker = "sys_platform == 'linux'", specifier = ">=1.3.2" },
+    { name = "evdev-binary", marker = "sys_platform == 'linux'", specifier = ">=1.9.0" },
     { name = "meikiocr" },
     { name = "mss", specifier = ">=9.0.0" },
     { name = "numpy" },
@@ -309,7 +323,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'", specifier = ">=0.0.9" },
     { name = "pygobject", marker = "sys_platform == 'linux'", specifier = ">=3.42.0" },
-    { name = "pynput", specifier = ">=1.7.0" },
+    { name = "pynput", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=1.7.0" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'", specifier = ">=12.1" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'", specifier = ">=10.0" },
     { name = "pyside6", specifier = ">=6.6.0" },
@@ -567,11 +581,11 @@ name = "pynput"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "evdev", marker = "'linux' in sys_platform" },
+    { name = "evdev", marker = "(platform_machine != 'aarch64' and 'linux' in sys_platform) or (sys_platform != 'linux' and 'linux' in sys_platform)" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
-    { name = "python-xlib", marker = "'linux' in sys_platform" },
-    { name = "six" },
+    { name = "python-xlib", marker = "(platform_machine != 'aarch64' and 'linux' in sys_platform) or (sys_platform != 'linux' and 'linux' in sys_platform)" },
+    { name = "six", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Use `evdev-binary` (pre-built wheels) on Linux instead of letting `pynput` pull in `evdev` from source
- Make `pynput` conditional to macOS/Windows only since Linux uses `evdev` directly in `keyboard.py`

## Problem

On Steam Deck and other Arch Linux systems, `evdev` fails to build because it requires kernel headers (`linux/input.h`) which are not available on systems with immutable filesystems.

## Solution

Since the code already imports `evdev` directly on Linux (not through `pynput`), we:
1. Remove `pynput` from Linux dependencies (it was unused there anyway)
2. Add `evdev-binary` which provides pre-built wheels with the same API

## Test plan

- [ ] Install on Steam Deck (Desktop mode)
- [ ] Install on standard Linux (Wayland)
- [ ] Install on macOS
- [ ] Install on Windows
- [ ] Verify global hotkeys work on all platforms

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)