### PR TITLE
Add Models UI section with status and Fix Models button (#139)

### DIFF
--- a/src/interpreter/ocr.py
+++ b/src/interpreter/ocr.py
@@ -7,13 +7,8 @@ from numpy.typing import NDArray
 
 from . import log
 from .capture.convert import bgra_to_rgb
-from .models import load_with_retry
 
 logger = log.get_logger()
-
-# MeikiOCR HuggingFace repositories (used for cache cleanup on failure)
-MEIKI_DET_REPO = "rtr46/meiki.text.detect.v0"
-MEIKI_REC_REPO = "rtr46/meiki.txt.recognition.v0"
 
 # Detection thresholds
 DEFAULT_CONFIDENCE_THRESHOLD = 0.6  # Minimum avg confidence per line (0.0-1.0)
@@ -67,24 +62,16 @@ class OCR:
         """Load the MeikiOCR model.
 
         Raises:
-            ModelLoadError: If model fails to load after recovery attempts.
+            Exception: If model fails to load.
         """
         if self._model is not None:
             return
 
         logger.info("loading meikiocr")
+        from meikiocr import MeikiOCR
 
-        def _do_load():
-            from meikiocr import MeikiOCR
-
-            self._model = MeikiOCR()
-            logger.info("meikiocr ready")
-
-        load_with_retry(
-            load_fn=_do_load,
-            repo_ids=[MEIKI_DET_REPO, MEIKI_REC_REPO],
-            model_name="OCR model (MeikiOCR)",
-        )
+        self._model = MeikiOCR()
+        logger.info("meikiocr ready")
 
     def _run_ocr_and_filter(self, image: NDArray[np.uint8]) -> list[dict]:
         """Run OCR and filter results by confidence threshold.


### PR DESCRIPTION
## Summary
- Adds a visible "Models" section at the top of the UI showing loading/ready/error status for OCR and Translation models
- Adds validation to detect corrupted/incomplete model downloads before use
- Adds "Fix Models" button that clears corrupted caches and re-downloads when issues occur
- Disables "Start Capture" button until both models are loaded

Fixes #139

## Changes
- **models.py** (new): Shared utilities for HuggingFace cache path resolution and deletion
- **translate.py**: Added validation for required model files, raises `ModelLoadError` if corrupted
- **ocr.py**: Simplified error handling, lets errors propagate with clear messages
- **workers.py**: Added per-model status signals (`ocr_status`, `translation_status`) and failure tracking
- **main_window.py**: Added Models UI section with status labels and Fix Models button

## UI States
| State | Display |
|-------|---------|
| Loading | "Loading..." (gray) |
| Downloading | "Downloading..." (gray) |
| Ready | "Ready ✓" (green) |
| Error | "Error ✗" (red) + Fix Models button |

## Test plan
- [ ] Start app with no cached models → should show "Loading..." then "Ready ✓"
- [ ] Delete model cache manually, restart → should download and show "Ready ✓"
- [ ] Corrupt model cache (delete model.bin), restart → should show "Error ✗" and Fix Models button
- [ ] Click Fix Models → should re-download and show "Ready ✓"
- [ ] Verify "Start Capture" is disabled until models are ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)