### PR TITLE
Use HWND for Windows capture instead of window title

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     "pyobjc-framework-Quartz>=10.0; sys_platform == 'darwin'",
     # Windows only - window capture
     "pygetwindow>=0.0.9; sys_platform == 'win32'",
-    "windows-capture>=1.4.0; sys_platform == 'win32'",
+    # Using fork with HWND support (https://github.com/bquenin/windows-capture/releases/tag/v1.5.1)
+    "windows-capture @ https://github.com/bquenin/windows-capture/releases/download/v1.5.1/windows_capture-1.5.1-cp39-abi3-win_amd64.whl ; sys_platform == 'win32'",
     # Linux only - window capture (X11)
     "python-xlib>=0.33; sys_platform == 'linux'",
     # Linux only - window capture (Wayland via PipeWire portal)
@@ -58,6 +59,9 @@ interpreter-v2 = "interpreter:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/interpreter"]

--- a/src/interpreter/capture/__init__.py
+++ b/src/interpreter/capture/__init__.py
@@ -249,8 +249,8 @@ class WindowCapture:
 
         # Create platform-specific stream
         if _system == "Windows":
-            # Windows uses exact window title for capture
-            self._stream = CaptureStream(self._actual_title)
+            # Windows uses HWND for reliable capture (immune to dynamic titles)
+            self._stream = CaptureStream(self._window_id)
         elif _system == "Linux":
             # Linux uses background thread with configurable interval
             self._stream = CaptureStream(self._window_id, self._capture_interval)

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "interpreter-v2"
-version = "2.11.0"
+version = "2.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "ctranslate2" },
@@ -333,7 +333,7 @@ requires-dist = [
     { name = "sentencepiece" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "tqdm" },
-    { name = "windows-capture", marker = "sys_platform == 'win32'", specifier = ">=1.4.0" },
+    { name = "windows-capture", marker = "sys_platform == 'win32'", url = "https://github.com/bquenin/windows-capture/releases/download/v1.5.1/windows_capture-1.5.1-cp39-abi3-win_amd64.whl" },
 ]
 
 [package.metadata.requires-dev]
@@ -932,13 +932,18 @@ wheels = [
 
 [[package]]
 name = "windows-capture"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
+version = "1.5.1"
+source = { url = "https://github.com/bquenin/windows-capture/releases/download/v1.5.1/windows_capture-1.5.1-cp39-abi3-win_amd64.whl" }
 dependencies = [
     { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
     { name = "opencv-python", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/78/bf3363d6f0890171efba9bbd4e1f36b47afa1e643a7bc7c9059176c8fb33/windows_capture-1.5.0.tar.gz", hash = "sha256:9931224dac5db4d6e35b7c3b2d02f6df8ff04caa5c95eac2401a7dd2db95b5ce", size = 48182, upload-time = "2025-06-30T00:03:52.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/46/c43c7881bfa3f29f7b87ab0385654d08f808722bd09aebc52ce9ba4eace5/windows_capture-1.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:262819089fbe142cf298b6bfde0eb93c27b6db09ac9828b9ed6653714041654f", size = 220395, upload-time = "2025-06-30T00:03:50.118Z" },
+    { url = "https://github.com/bquenin/windows-capture/releases/download/v1.5.1/windows_capture-1.5.1-cp39-abi3-win_amd64.whl", hash = "sha256:1adb63dba039c14be74b290dd47a3717368c8c7df78dda06f42b5c2a5acf68bb" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy" },
+    { name = "opencv-python" },
 ]


### PR DESCRIPTION
## Summary
- Use HWND (window handle) for Windows capture instead of window title
- More reliable capture immune to dynamic window titles (e.g., RetroArch showing FPS)
- Uses forked windows-capture library v1.5.1 with HWND support from GitHub releases

## Test plan
- [x] Test capture with Snes9x (dynamic title with FPS)
- [x] Verify capture continues working when window title changes
- [x] Confirm logs show HWND-based capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)