### PR TITLE
Add uninstall scripts for macOS/Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Then run with `interpreter-v2`.
 
 To update to the latest version, run the installer again (see Installation above).
 
+## Uninstalling
+
+**macOS/Linux:**
+```bash
+curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/uninstall.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/uninstall.ps1 | iex"
+```
+
+This removes interpreter-v2, config files, and cached models.
+
 ## Usage
 
 ```bash

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,60 @@
+# uninstall.ps1 - Uninstaller for interpreter-v2
+# Usage: powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/uninstall.ps1 | iex"
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host ""
+Write-Host "=== interpreter-v2 Uninstaller ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Check if uv is installed
+$uvPath = Get-Command uv -ErrorAction SilentlyContinue
+if (-not $uvPath) {
+    Write-Host "uv is not installed. Nothing to uninstall." -ForegroundColor Yellow
+    exit 0
+}
+
+# Check if interpreter-v2 is installed
+$toolList = uv tool list 2>$null
+if ($toolList -notmatch "interpreter-v2") {
+    Write-Host "interpreter-v2 is not installed." -ForegroundColor Yellow
+} else {
+    Write-Host "[1/2] Uninstalling interpreter-v2..." -ForegroundColor Yellow
+    uv tool uninstall interpreter-v2
+    Write-Host "interpreter-v2 uninstalled" -ForegroundColor Green
+}
+
+# Remove user data
+Write-Host "[2/2] Removing user data..." -ForegroundColor Yellow
+
+$configDir = "$env:USERPROFILE\.interpreter"
+$modelsDir = "$env:USERPROFILE\.cache\huggingface\hub"
+
+# Remove config
+if (Test-Path $configDir) {
+    Remove-Item -Recurse -Force $configDir
+    Write-Host "     Removed config directory" -ForegroundColor Green
+} else {
+    Write-Host "     Config directory not found" -ForegroundColor Gray
+}
+
+# Remove cached models
+if (Test-Path $modelsDir) {
+    $interpreterModels = Get-ChildItem -Path $modelsDir -Directory -Filter "models--bquenin--*" -ErrorAction SilentlyContinue
+    if ($interpreterModels) {
+        foreach ($model in $interpreterModels) {
+            Remove-Item -Recurse -Force $model.FullName
+            Write-Host "     Removed $($model.Name)" -ForegroundColor Green
+        }
+    } else {
+        Write-Host "     Cached models not found" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "     Cached models not found" -ForegroundColor Gray
+}
+
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Green
+Write-Host "  Uninstall complete!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Green
+Write-Host ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# uninstall.sh - Uninstaller for interpreter-v2
+# Usage: curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/uninstall.sh | bash
+
+set -e
+
+# Colors
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+GRAY='\033[0;90m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo ""
+echo -e "${CYAN}=== interpreter-v2 Uninstaller ===${NC}"
+echo ""
+
+# Check if uv is installed
+if ! command -v uv &> /dev/null; then
+    echo -e "${YELLOW}uv is not installed. Nothing to uninstall.${NC}"
+    exit 0
+fi
+
+# Check if interpreter-v2 is installed
+if ! uv tool list 2>/dev/null | grep -q "interpreter-v2"; then
+    echo -e "${YELLOW}interpreter-v2 is not installed.${NC}"
+else
+    echo -e "${YELLOW}[1/3] Uninstalling interpreter-v2...${NC}"
+    uv tool uninstall interpreter-v2
+    echo -e "${GREEN}interpreter-v2 uninstalled${NC}"
+fi
+
+# Remove desktop entry and icon (Linux only)
+if [[ "$(uname)" == "Linux" ]]; then
+    echo -e "${YELLOW}[2/3] Removing desktop entry and icon...${NC}"
+
+    DESKTOP_FILE="$HOME/.local/share/applications/interpreter-v2.desktop"
+    ICON_FILE="$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
+
+    if [ -f "$DESKTOP_FILE" ]; then
+        rm -f "$DESKTOP_FILE"
+        echo -e "${GREEN}     Removed desktop entry${NC}"
+    else
+        echo -e "${GRAY}     Desktop entry not found${NC}"
+    fi
+
+    if [ -f "$ICON_FILE" ]; then
+        rm -f "$ICON_FILE"
+        echo -e "${GREEN}     Removed icon${NC}"
+    else
+        echo -e "${GRAY}     Icon not found${NC}"
+    fi
+
+    # Update caches
+    gtk-update-icon-cache -f "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+    update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+else
+    echo -e "${GRAY}[2/3] Skipping desktop entry removal (not Linux)${NC}"
+fi
+
+# Remove user data
+echo -e "${YELLOW}[3/3] Removing user data...${NC}"
+
+CONFIG_DIR="$HOME/.interpreter"
+MODELS_DIR="$HOME/.cache/huggingface/hub"
+
+# Remove config
+if [ -d "$CONFIG_DIR" ]; then
+    rm -rf "$CONFIG_DIR"
+    echo -e "${GREEN}     Removed config directory${NC}"
+else
+    echo -e "${GRAY}     Config directory not found${NC}"
+fi
+
+# Remove cached models
+INTERPRETER_MODELS=$(find "$MODELS_DIR" -maxdepth 1 -type d -name "models--bquenin--*" 2>/dev/null || true)
+if [ -n "$INTERPRETER_MODELS" ]; then
+    echo "$INTERPRETER_MODELS" | while read -r model; do
+        rm -rf "$model"
+        echo -e "${GREEN}     Removed $(basename "$model")${NC}"
+    done
+else
+    echo -e "${GRAY}     Cached models not found${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  Uninstall complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""


### PR DESCRIPTION
## Summary
- Add `uninstall.sh` for macOS/Linux
- Add `uninstall.ps1` for Windows
- Update README with uninstall instructions

### What the scripts remove:
- interpreter-v2 via `uv tool uninstall`
- Config directory (`~/.interpreter`)
- Cached models (`~/.cache/huggingface/hub/models--bquenin--*`)
- Desktop entry and icon (Linux only)

Closes #182

## Test plan
- [x] Tested uninstall.sh on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)