### PR TITLE
Add macOS permissions UI section

### DIFF
--- a/src/interpreter/permissions/__init__.py
+++ b/src/interpreter/permissions/__init__.py
@@ -1,0 +1,38 @@
+"""Platform-specific permission checking."""
+
+import platform
+
+
+def is_macos() -> bool:
+    """Check if running on macOS."""
+    return platform.system() == "Darwin"
+
+
+if platform.system() == "Darwin":
+    from .macos import (
+        check_accessibility,
+        check_screen_recording,
+        open_accessibility_settings,
+        open_screen_recording_settings,
+        request_accessibility,
+        request_screen_recording,
+    )
+else:
+    # Stub functions for non-macOS platforms
+    def check_screen_recording() -> bool:
+        return True
+
+    def check_accessibility() -> bool:
+        return True
+
+    def request_screen_recording() -> bool:
+        return True
+
+    def request_accessibility() -> bool:
+        return True
+
+    def open_screen_recording_settings() -> None:
+        pass
+
+    def open_accessibility_settings() -> None:
+        pass

--- a/src/interpreter/permissions/macos.py
+++ b/src/interpreter/permissions/macos.py
@@ -1,0 +1,86 @@
+"""macOS permission checking and requesting."""
+
+import subprocess
+
+
+def check_screen_recording() -> bool:
+    """Check if Screen Recording permission is granted.
+
+    Returns:
+        True if permission is granted, False otherwise.
+    """
+    try:
+        import Quartz.CoreGraphics as CG
+
+        return CG.CGPreflightScreenCaptureAccess()
+    except Exception:
+        return False
+
+
+def check_accessibility() -> bool:
+    """Check if Accessibility permission is granted.
+
+    This is required for global hotkeys (pynput uses Quartz event taps).
+
+    Returns:
+        True if permission is granted, False otherwise.
+    """
+    try:
+        from ApplicationServices import AXIsProcessTrusted
+
+        return AXIsProcessTrusted()
+    except Exception:
+        return False
+
+
+def request_screen_recording() -> bool:
+    """Request Screen Recording permission.
+
+    This will trigger the system permission dialog if the user
+    hasn't been prompted before. If already denied, it won't
+    re-prompt - user must go to System Settings.
+
+    Returns:
+        True if permission is granted, False otherwise.
+    """
+    try:
+        import Quartz.CoreGraphics as CG
+
+        return CG.CGRequestScreenCaptureAccess()
+    except Exception:
+        return False
+
+
+def request_accessibility() -> bool:
+    """Request Accessibility permission.
+
+    This will prompt the user to grant accessibility access.
+    Required for global hotkeys.
+
+    Returns:
+        True if permission is granted, False otherwise.
+    """
+    try:
+        from ApplicationServices import AXIsProcessTrustedWithOptions
+        from Foundation import NSDictionary
+
+        # kAXTrustedCheckOptionPrompt = True will show the prompt
+        options = NSDictionary.dictionaryWithObject_forKey_(True, "AXTrustedCheckOptionPrompt")
+        return AXIsProcessTrustedWithOptions(options)
+    except Exception:
+        return False
+
+
+def open_screen_recording_settings() -> None:
+    """Open System Settings to the Screen Recording pane."""
+    subprocess.run(
+        ["open", "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"], check=False
+    )
+
+
+def open_accessibility_settings() -> None:
+    """Open System Settings to the Accessibility pane."""
+    subprocess.run(
+        ["open", "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"],
+        check=False,
+    )


### PR DESCRIPTION
## Summary
- Add permissions module to check Screen Recording and Accessibility permissions on macOS
- Show permission status in UI with visual indicators (✓ Granted / ✗ Required)
- Grant button triggers system permission dialog or opens System Settings
- Section only appears on macOS (hidden on Windows/Linux)

**UI Preview:**
```
┌─ macOS Permissions ─────────────────────────────┐
│ Screen Recording   ✓ Granted                    │
│ Accessibility      ✗ Required    [Grant]        │
└─────────────────────────────────────────────────┘
```

Closes #178

## Test plan
- [x] Tested on macOS - permissions display correctly
- [x] Grant button opens System Settings to correct pane
- [ ] Verify section is hidden on Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)