### PR TITLE
Fix font size not working on Linux 4K monitors

### DIFF
--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -29,6 +29,7 @@ class Config:
         window_title: str = "Snes9x",
         ocr_confidence: float = 0.6,
         overlay_mode: str = "banner",
+        font_family: str | None = None,
         font_size: int = 26,
         font_color: str = "#FFFFFF",
         background_color: str = "#404040",
@@ -40,6 +41,7 @@ class Config:
         self.window_title = window_title
         self.ocr_confidence = ocr_confidence
         self.overlay_mode = overlay_mode  # "banner" or "inplace"
+        self.font_family = font_family  # None = system default
         self.font_size = font_size
         self.font_color = font_color
         self.background_color = background_color
@@ -86,6 +88,7 @@ class Config:
                 window_title=data.get("window_title", cls.DEFAULT_WINDOW_TITLE),
                 ocr_confidence=float(data.get("ocr_confidence", 0.6)),
                 overlay_mode=data.get("overlay_mode", "banner"),
+                font_family=data.get("font_family"),  # None = system default
                 font_size=int(data.get("font_size", 26)),
                 font_color=data.get("font_color", "#FFFFFF"),
                 background_color=data.get("background_color", "#404040"),
@@ -176,6 +179,9 @@ hotkeys:
             "background_color": str(self.background_color),
             "hotkeys": {str(k): str(v) for k, v in self.hotkeys.items()},
         }
+        # Only save font_family if user has chosen one (None = system default)
+        if self.font_family is not None:
+            data["font_family"] = str(self.font_family)
         # Only save banner position if it was set (user has moved the banner)
         if self.banner_x is not None:
             data["banner_x"] = int(self.banner_x)

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -3,11 +3,12 @@
 import os
 
 from PySide6.QtCore import Qt, QTimer, Signal
-from PySide6.QtGui import QImage, QKeySequence, QPixmap
+from PySide6.QtGui import QFont, QImage, QKeySequence, QPixmap
 from PySide6.QtWidgets import (
     QButtonGroup,
     QColorDialog,
     QComboBox,
+    QFontDialog,
     QFrame,
     QGridLayout,
     QGroupBox,
@@ -42,7 +43,6 @@ from .workers import ProcessWorker
 logger = log.get_logger()
 
 # Font settings
-FONT_FAMILY = "Helvetica"
 MIN_FONT_SIZE = 8
 MAX_FONT_SIZE = 72
 
@@ -89,13 +89,13 @@ class MainWindow(QMainWindow):
 
         # Overlays
         self._banner_overlay = BannerOverlay(
-            font_family=FONT_FAMILY,
+            font_family=config.font_family,
             font_size=config.font_size,
             font_color=config.font_color,
             background_color=config.background_color,
         )
         self._inplace_overlay = InplaceOverlay(
-            font_family=FONT_FAMILY,
+            font_family=config.font_family,
             font_size=config.font_size,
             font_color=config.font_color,
             background_color=config.background_color,
@@ -297,18 +297,24 @@ class MainWindow(QMainWindow):
         self._font_label = QLabel(f"{self._config.font_size}pt")
         settings_layout.addWidget(self._font_label, 1, 2)
 
+        # Font family
+        settings_layout.addWidget(QLabel("Font:"), 2, 0)
+        self._font_family_btn = QPushButton(self._config.font_family or "System Default")
+        self._font_family_btn.clicked.connect(self._pick_font_family)
+        settings_layout.addWidget(self._font_family_btn, 2, 1)
+
         # Colors
-        settings_layout.addWidget(QLabel("Font Color:"), 2, 0)
+        settings_layout.addWidget(QLabel("Font Color:"), 3, 0)
         self._font_color_btn = QPushButton()
         self._font_color_btn.setStyleSheet(f"background-color: {self._config.font_color};")
         self._font_color_btn.clicked.connect(self._pick_font_color)
-        settings_layout.addWidget(self._font_color_btn, 2, 1)
+        settings_layout.addWidget(self._font_color_btn, 3, 1)
 
-        settings_layout.addWidget(QLabel("Background:"), 3, 0)
+        settings_layout.addWidget(QLabel("Background:"), 4, 0)
         self._bg_color_btn = QPushButton()
         self._bg_color_btn.setStyleSheet(f"background-color: {self._config.background_color};")
         self._bg_color_btn.clicked.connect(self._pick_bg_color)
-        settings_layout.addWidget(self._bg_color_btn, 3, 1)
+        settings_layout.addWidget(self._bg_color_btn, 4, 1)
 
         layout.addWidget(settings_group)
 
@@ -910,6 +916,22 @@ class MainWindow(QMainWindow):
         self._font_label.setText(f"{value}pt")
         self._banner_overlay.set_font_size(value)
         self._inplace_overlay.set_font_size(value)
+
+    def _pick_font_family(self):
+        # Initialize dialog with current font
+        if self._config.font_family:
+            initial_font = QFont(self._config.font_family)
+        else:
+            initial_font = QFont()
+        initial_font.setPointSize(self._config.font_size)
+
+        ok, font = QFontDialog.getFont(initial_font, self)
+        if ok:
+            font_family = font.family()
+            self._config.font_family = font_family
+            self._font_family_btn.setText(font_family)
+            self._banner_overlay.set_font_family(font_family)
+            self._inplace_overlay.set_font_family(font_family)
 
     def _pick_font_color(self):
         color = QColorDialog.getColor()

--- a/src/interpreter/overlay/base.py
+++ b/src/interpreter/overlay/base.py
@@ -32,14 +32,14 @@ class BannerOverlayBase(QWidget):
 
     def __init__(
         self,
-        font_family: str = "Helvetica",
+        font_family: str | None = None,
         font_size: int = 24,
         font_color: str = "#FFFFFF",
         background_color: str = "#404040",
     ):
         super().__init__()
         self._drag_pos: QPoint | None = None
-        self._font_family = font_family
+        self._font_family = font_family  # None = system default
         self._font_size = font_size
         self._font_color = font_color
         self._background_color = background_color
@@ -79,9 +79,19 @@ class BannerOverlayBase(QWidget):
         self._update_label_style()
         layout.addWidget(self._label)
 
+    def _create_font(self) -> QFont:
+        """Create a font with current family and size settings."""
+        if self._font_family:
+            font = QFont(self._font_family)
+        else:
+            font = QFont()  # System default font
+        font.setPointSize(self._font_size)
+        font.setWeight(QFont.Weight.Bold)
+        return font
+
     def _update_label_style(self):
         """Update label font and color."""
-        self._label.setFont(QFont(self._font_family, self._font_size, QFont.Weight.Bold))
+        self._label.setFont(self._create_font())
         self._label.setStyleSheet(f"color: {self._font_color}; background: transparent;")
 
     def _move_to_bottom(self):
@@ -99,6 +109,12 @@ class BannerOverlayBase(QWidget):
     def set_font_size(self, size: int):
         """Update the font size."""
         self._font_size = size
+        self._update_label_style()
+        self._resize_to_fit()
+
+    def set_font_family(self, font_family: str | None):
+        """Update the font family. None = system default."""
+        self._font_family = font_family
         self._update_label_style()
         self._resize_to_fit()
 
@@ -187,14 +203,14 @@ class InplaceOverlayBase(QWidget):
 
     def __init__(
         self,
-        font_family: str = "Helvetica",
+        font_family: str | None = None,
         font_size: int = 18,
         font_color: str = "#FFFFFF",
         background_color: str = "#404040",
     ):
         super().__init__()
         self._labels: list[QLabel] = []
-        self._font_family = font_family
+        self._font_family = font_family  # None = system default
         self._font_size = font_size
         self._font_color = font_color
         self._background_color = background_color
@@ -239,6 +255,16 @@ class InplaceOverlayBase(QWidget):
             screen = QApplication.primaryScreen()
         return screen.devicePixelRatio()
 
+    def _create_font(self) -> QFont:
+        """Create a font with current family and size settings."""
+        if self._font_family:
+            font = QFont(self._font_family)
+        else:
+            font = QFont()  # System default font
+        font.setPointSize(self._font_size)
+        font.setWeight(QFont.Weight.Bold)
+        return font
+
     def set_regions(self, regions: list[tuple[str, dict]], content_offset: tuple[int, int] = (0, 0)):
         """Update text regions.
 
@@ -260,7 +286,7 @@ class InplaceOverlayBase(QWidget):
             if not bbox:
                 continue
             label = QLabel(text, self)
-            label.setFont(QFont(self._font_family, self._font_size, QFont.Weight.Bold))
+            label.setFont(self._create_font())
             # Convert hex background color to rgba with transparency
             bg_color = self._background_color.lstrip("#")
             r, g, b = int(bg_color[0:2], 16), int(bg_color[2:4], 16), int(bg_color[4:6], 16)
@@ -305,6 +331,12 @@ class InplaceOverlayBase(QWidget):
     def set_font_size(self, size: int):
         """Update the font size and re-render immediately."""
         self._font_size = size
+        if self._last_regions:
+            self.set_regions(self._last_regions, self._last_content_offset)
+
+    def set_font_family(self, font_family: str | None):
+        """Update the font family and re-render immediately. None = system default."""
+        self._font_family = font_family
         if self._last_regions:
             self.set_regions(self._last_regions, self._last_content_offset)
 


### PR DESCRIPTION
## Summary
- Replace hardcoded "Helvetica" font with system default font, fixing font size issues on Linux (#173, #177)
- Add font picker button in Settings using Qt's `QFontDialog` so users can choose any installed font
- Selected font is persisted to `config.yml`

## Root Cause
Helvetica is not installed by default on Linux systems. When Qt can't find the requested font, it falls back to a substitute that may not respond correctly to size changes.

## Solution
Use `QFont()` with no family name to get the system default font, which is always available and properly configured. Added optional `font_family` parameter (default `None`) to allow users to pick a custom font if desired.

## Test plan
- [x] Existing tests pass
- [ ] Verify font size slider works on Linux with 4K monitor
- [ ] Verify font picker opens and allows selecting fonts
- [ ] Verify selected font persists after app restart
- [ ] Verify no regression on Windows/macOS

Fixes #173, fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)