### PR TITLE
Add background opacity slider for overlay transparency

### DIFF
--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -42,6 +42,7 @@ class Config:
         font_size: int = 26,
         font_color: str = "#FFFFFF",
         background_color: str = "#404040",
+        background_opacity: float = 0.8,
         hotkeys: dict | None = None,
         config_path: str | None = None,
         banner_x: int | None = None,
@@ -54,6 +55,7 @@ class Config:
         self.font_size = font_size
         self.font_color = font_color
         self.background_color = background_color
+        self.background_opacity = background_opacity
         self.hotkeys = hotkeys if hotkeys is not None else self.DEFAULT_HOTKEYS.copy()
         self.config_path = config_path
         self.banner_x = banner_x
@@ -109,6 +111,7 @@ class Config:
                 font_size=int(data.get("font_size", 26)),
                 font_color=data.get("font_color", "#FFFFFF"),
                 background_color=data.get("background_color", "#404040"),
+                background_opacity=float(data.get("background_opacity", 0.8)),
                 hotkeys=hotkeys,
                 config_path=config_path,
                 banner_x=data.get("banner_x"),
@@ -147,6 +150,7 @@ overlay_mode: banner
 font_size: 26
 font_color: "#FFFFFF"
 background_color: "#404040"
+background_opacity: 0.8  # 0.0 (transparent) to 1.0 (opaque)
 
 # Hotkeys - single characters or special key names
 # Special keys: f1-f12, escape, space, enter, tab, backspace, delete,
@@ -194,6 +198,7 @@ hotkeys:
             "font_size": int(self.font_size),
             "font_color": str(self.font_color),
             "background_color": str(self.background_color),
+            "background_opacity": float(self.background_opacity),
             "hotkeys": {str(k): str(v) for k, v in self.hotkeys.items()},
         }
         # Only save font_family if user has chosen one (None = system default)

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -94,12 +94,14 @@ class MainWindow(QMainWindow):
             font_size=config.font_size,
             font_color=config.font_color,
             background_color=config.background_color,
+            background_opacity=config.background_opacity,
         )
         self._inplace_overlay = InplaceOverlay(
             font_family=config.font_family,
             font_size=config.font_size,
             font_color=config.font_color,
             background_color=config.background_color,
+            background_opacity=config.background_opacity,
         )
 
         # Apply saved banner position if available
@@ -328,6 +330,16 @@ class MainWindow(QMainWindow):
         self._bg_color_btn.setStyleSheet(f"background-color: {self._config.background_color};")
         self._bg_color_btn.clicked.connect(self._pick_bg_color)
         settings_layout.addWidget(self._bg_color_btn, 4, 1)
+
+        # Opacity
+        settings_layout.addWidget(QLabel("Opacity:"), 5, 0)
+        self._opacity_slider = QSlider(Qt.Orientation.Horizontal)
+        self._opacity_slider.setRange(0, 100)
+        self._opacity_slider.setValue(int(self._config.background_opacity * 100))
+        self._opacity_slider.valueChanged.connect(self._on_opacity_changed)
+        settings_layout.addWidget(self._opacity_slider, 5, 1)
+        self._opacity_label = QLabel(f"{int(self._config.background_opacity * 100)}%")
+        settings_layout.addWidget(self._opacity_label, 5, 2)
 
         layout.addWidget(settings_group)
 
@@ -945,6 +957,13 @@ class MainWindow(QMainWindow):
         self._font_label.setText(f"{value}pt")
         self._banner_overlay.set_font_size(value)
         self._inplace_overlay.set_font_size(value)
+
+    def _on_opacity_changed(self, value: int):
+        opacity = value / 100.0
+        self._config.background_opacity = opacity
+        self._opacity_label.setText(f"{value}%")
+        self._banner_overlay.set_opacity(opacity)
+        self._inplace_overlay.set_opacity(opacity)
 
     def _pick_font_family(self):
         # Initialize dialog with current font


### PR DESCRIPTION
## Summary
- Adds an "Opacity" slider (0-100%) in the Settings section
- Controls background transparency of both banner and inplace overlay modes
- Text remains fully opaque for readability
- Setting persists in config file (`background_opacity`)

Related to #153 - awaiting clarification on whether full window opacity (text + background) is also desired.

## Test plan
- [ ] Run `uv run interpreter`
- [ ] Adjust the Opacity slider in Settings
- [ ] Verify banner mode background becomes transparent (text stays readable)
- [ ] Switch to inplace mode, verify label backgrounds also change
- [ ] Restart app, verify opacity setting persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)