### PR TITLE
Use xdg-icon-resource for Linux icon installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,9 +14,9 @@ NC='\033[0m' # No Color
 
 # Determine total steps (Linux has extra steps)
 if [[ "$(uname)" == "Linux" ]]; then
-    TOTAL_STEPS=5
+	TOTAL_STEPS=5
 else
-    TOTAL_STEPS=3
+	TOTAL_STEPS=3
 fi
 
 echo ""
@@ -25,21 +25,21 @@ echo "Offline screen translator for Japanese retro games"
 echo ""
 
 # Check if uv is installed
-if ! command -v uv &> /dev/null; then
-    echo -e "${YELLOW}[1/${TOTAL_STEPS}] Installing uv package manager...${NC}"
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+if ! command -v uv &>/dev/null; then
+	echo -e "${YELLOW}[1/${TOTAL_STEPS}] Installing uv package manager...${NC}"
+	curl -LsSf https://astral.sh/uv/install.sh | sh
 
-    # Add uv to PATH for this session
-    export PATH="$HOME/.local/bin:$PATH"
+	# Add uv to PATH for this session
+	export PATH="$HOME/.local/bin:$PATH"
 
-    # Verify uv is now available
-    if ! command -v uv &> /dev/null; then
-        echo -e "${RED}Error: uv installation failed. Please restart your terminal and try again.${NC}"
-        exit 1
-    fi
-    echo -e "${GREEN}uv installed successfully!${NC}"
+	# Verify uv is now available
+	if ! command -v uv &>/dev/null; then
+		echo -e "${RED}Error: uv installation failed. Please restart your terminal and try again.${NC}"
+		exit 1
+	fi
+	echo -e "${GREEN}uv installed successfully!${NC}"
 else
-    echo -e "${GREEN}[1/${TOTAL_STEPS}] uv is already installed${NC}"
+	echo -e "${GREEN}[1/${TOTAL_STEPS}] uv is already installed${NC}"
 fi
 
 # Install or upgrade interpreter-v2
@@ -47,59 +47,59 @@ echo -e "${YELLOW}[2/${TOTAL_STEPS}] Installing interpreter-v2 from PyPI...${NC}
 echo -e "${GRAY}     (this may take a minute on first install)${NC}"
 # Use Python 3.12 - uv-managed Python includes tkinter, system Python 3.13+ often doesn't
 if ! uv tool install --upgrade --python 3.12 interpreter-v2 2>&1; then
-    echo ""
-    echo -e "${RED}Installation failed!${NC}"
-    echo -e "${YELLOW}This may be due to missing dependencies. Try:${NC}"
-    echo -e "  uv python install 3.12"
-    echo -e "  Then run this installer again."
-    exit 1
+	echo ""
+	echo -e "${RED}Installation failed!${NC}"
+	echo -e "${YELLOW}This may be due to missing dependencies. Try:${NC}"
+	echo -e "  uv python install 3.12"
+	echo -e "  Then run this installer again."
+	exit 1
 fi
-uv tool update-shell > /dev/null 2>&1 || true
+uv tool update-shell >/dev/null 2>&1 || true
 
 # Pre-compile bytecode and warm up OS caches
 echo -e "${YELLOW}[3/${TOTAL_STEPS}] Optimizing for fast startup...${NC}"
 TOOL_DIR="$HOME/.local/share/uv/tools/interpreter-v2"
 if [ -d "$TOOL_DIR" ]; then
-    # Compile bytecode (exclude .tmpl.py template files that aren't valid Python)
-    "$TOOL_DIR/bin/python" -m compileall -q -x '\.tmpl\.py$' "$TOOL_DIR/lib" 2>/dev/null || true
-    # Warm up OS caches by running once
-    interpreter-v2 --list-windows > /dev/null 2>&1 || true
+	# Compile bytecode (exclude .tmpl.py template files that aren't valid Python)
+	"$TOOL_DIR/bin/python" -m compileall -q -x '\.tmpl\.py$' "$TOOL_DIR/lib" 2>/dev/null || true
+	# Warm up OS caches by running once
+	interpreter-v2 --list-windows >/dev/null 2>&1 || true
 fi
 
 # Check Wayland dependencies (Linux only)
 # Always check regardless of WAYLAND_DISPLAY - some compositors like gamescope don't set it
 if [[ "$(uname)" == "Linux" ]]; then
-    echo -e "${YELLOW}[4/${TOTAL_STEPS}] Checking Wayland capture dependencies...${NC}"
+	echo -e "${YELLOW}[4/${TOTAL_STEPS}] Checking Wayland capture dependencies...${NC}"
 
-    if ldconfig -p 2>/dev/null | grep -q libpipewire-0.3; then
-        echo -e "${GREEN}     PipeWire library available${NC}"
-    else
-        echo -e "${YELLOW}     libpipewire-0.3 not found. Wayland capture may not work.${NC}"
-        echo -e "${GRAY}     Install with: apt install libpipewire-0.3-0 (Debian/Ubuntu)${NC}"
-        echo -e "${GRAY}                   dnf install pipewire (Fedora)${NC}"
-        echo -e "${GRAY}                   pacman -S pipewire (Arch)${NC}"
-    fi
+	if ldconfig -p 2>/dev/null | grep -q libpipewire-0.3; then
+		echo -e "${GREEN}     PipeWire library available${NC}"
+	else
+		echo -e "${YELLOW}     libpipewire-0.3 not found. Wayland capture may not work.${NC}"
+		echo -e "${GRAY}     Install with: apt install libpipewire-0.3-0 (Debian/Ubuntu)${NC}"
+		echo -e "${GRAY}                   dnf install pipewire (Fedora)${NC}"
+		echo -e "${GRAY}                   pacman -S pipewire (Arch)${NC}"
+	fi
 fi
 
 # Install desktop entry and icon (Linux only)
 if [[ "$(uname)" == "Linux" ]]; then
-    echo -e "${YELLOW}[5/${TOTAL_STEPS}] Installing desktop entry...${NC}"
+	echo -e "${YELLOW}[5/${TOTAL_STEPS}] Installing desktop entry...${NC}"
 
-    # Find the installed icon
-    ICON_SRC=$(find "$TOOL_DIR/lib" -name "icon.png" -path "*/resources/icons/*" 2>/dev/null | head -1)
+	# Find the installed icon
+	ICON_SRC=$(find "$TOOL_DIR/lib" -name "icon.png" -path "*/resources/icons/*" 2>/dev/null | head -1)
 
-    if [ -n "$ICON_SRC" ]; then
-        # Install icon using xdg-icon-resource if available, otherwise fall back to manual copy
-        if command -v xdg-icon-resource &> /dev/null; then
-            xdg-icon-resource install --novendor --size 256 "$ICON_SRC" interpreter-v2
-        else
-            mkdir -p "$HOME/.local/share/icons/hicolor/256x256/apps"
-            cp "$ICON_SRC" "$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
-            gtk-update-icon-cache -f "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
-        fi
-        # Install desktop entry
-        mkdir -p "$HOME/.local/share/applications"
-        cat > "$HOME/.local/share/applications/interpreter-v2.desktop" << 'EOF'
+	if [ -n "$ICON_SRC" ]; then
+		# Install icon using xdg-icon-resource if available, otherwise fall back to manual copy
+		if command -v xdg-icon-resource &>/dev/null; then
+			xdg-icon-resource install --novendor --size 256 "$ICON_SRC" interpreter-v2
+		else
+			mkdir -p "$HOME/.local/share/icons/hicolor/256x256/apps"
+			cp "$ICON_SRC" "$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
+			gtk-update-icon-cache -f "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+		fi
+		# Install desktop entry
+		mkdir -p "$HOME/.local/share/applications"
+		cat >"$HOME/.local/share/applications/interpreter-v2.desktop" <<'EOF'
 [Desktop Entry]
 Name=Interpreter
 Comment=Offline screen translator for Japanese games
@@ -110,12 +110,12 @@ Categories=Utility;Translation;
 StartupWMClass=interpreter-v2
 EOF
 
-        update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+		update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
 
-        echo -e "${GREEN}Desktop entry installed${NC}"
-    else
-        echo -e "${GRAY}Skipping desktop entry (icon not found)${NC}"
-    fi
+		echo -e "${GREEN}Desktop entry installed${NC}"
+	else
+		echo -e "${GRAY}Skipping desktop entry (icon not found)${NC}"
+	fi
 fi
 
 echo ""
@@ -128,12 +128,12 @@ echo ""
 echo -e "  ${CYAN}interpreter-v2${NC}"
 echo ""
 if [[ "$(uname)" == "Linux" ]]; then
-    echo -e "${YELLOW}Hotkeys:${NC} To use global hotkeys, add yourself to the input group:"
-    echo ""
-    echo -e "  ${CYAN}sudo usermod -aG input \$USER${NC}"
-    echo ""
-    echo "Then log out and back in."
-    echo ""
+	echo -e "${YELLOW}Hotkeys:${NC} To use global hotkeys, add yourself to the input group:"
+	echo ""
+	echo -e "  ${CYAN}sudo usermod -aG input \$USER${NC}"
+	echo ""
+	echo "Then log out and back in."
+	echo ""
 fi
 echo "You may need to restart your terminal first."
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -17,50 +17,50 @@ echo -e "${CYAN}=== interpreter-v2 Uninstaller ===${NC}"
 echo ""
 
 # Check if uv is installed
-if ! command -v uv &> /dev/null; then
-    echo -e "${YELLOW}uv is not installed. Nothing to uninstall.${NC}"
-    exit 0
+if ! command -v uv &>/dev/null; then
+	echo -e "${YELLOW}uv is not installed. Nothing to uninstall.${NC}"
+	exit 0
 fi
 
 # Check if interpreter-v2 is installed
 if ! uv tool list 2>/dev/null | grep -q "interpreter-v2"; then
-    echo -e "${YELLOW}interpreter-v2 is not installed.${NC}"
+	echo -e "${YELLOW}interpreter-v2 is not installed.${NC}"
 else
-    echo -e "${YELLOW}[1/3] Uninstalling interpreter-v2...${NC}"
-    uv tool uninstall interpreter-v2
-    echo -e "${GREEN}interpreter-v2 uninstalled${NC}"
+	echo -e "${YELLOW}[1/3] Uninstalling interpreter-v2...${NC}"
+	uv tool uninstall interpreter-v2
+	echo -e "${GREEN}interpreter-v2 uninstalled${NC}"
 fi
 
 # Remove desktop entry and icon (Linux only)
 if [[ "$(uname)" == "Linux" ]]; then
-    echo -e "${YELLOW}[2/3] Removing desktop entry and icon...${NC}"
+	echo -e "${YELLOW}[2/3] Removing desktop entry and icon...${NC}"
 
-    DESKTOP_FILE="$HOME/.local/share/applications/interpreter-v2.desktop"
-    ICON_FILE="$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
+	DESKTOP_FILE="$HOME/.local/share/applications/interpreter-v2.desktop"
+	ICON_FILE="$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
 
-    if [ -f "$DESKTOP_FILE" ]; then
-        rm -f "$DESKTOP_FILE"
-        echo -e "${GREEN}     Removed desktop entry${NC}"
-    else
-        echo -e "${GRAY}     Desktop entry not found${NC}"
-    fi
+	if [ -f "$DESKTOP_FILE" ]; then
+		rm -f "$DESKTOP_FILE"
+		echo -e "${GREEN}     Removed desktop entry${NC}"
+	else
+		echo -e "${GRAY}     Desktop entry not found${NC}"
+	fi
 
-    if command -v xdg-icon-resource &> /dev/null; then
-        xdg-icon-resource uninstall --size 256 interpreter-v2 2>/dev/null && \
-            echo -e "${GREEN}     Removed icon${NC}" || \
-            echo -e "${GRAY}     Icon not found${NC}"
-    elif [ -f "$ICON_FILE" ]; then
-        rm -f "$ICON_FILE"
-        gtk-update-icon-cache -f "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
-        echo -e "${GREEN}     Removed icon${NC}"
-    else
-        echo -e "${GRAY}     Icon not found${NC}"
-    fi
+	if command -v xdg-icon-resource &>/dev/null; then
+		xdg-icon-resource uninstall --size 256 interpreter-v2 2>/dev/null &&
+			echo -e "${GREEN}     Removed icon${NC}" ||
+			echo -e "${GRAY}     Icon not found${NC}"
+	elif [ -f "$ICON_FILE" ]; then
+		rm -f "$ICON_FILE"
+		gtk-update-icon-cache -f "$HOME/.local/share/icons/hicolor" 2>/dev/null || true
+		echo -e "${GREEN}     Removed icon${NC}"
+	else
+		echo -e "${GRAY}     Icon not found${NC}"
+	fi
 
-    # Update desktop database
-    update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+	# Update desktop database
+	update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
 else
-    echo -e "${GRAY}[2/3] Skipping desktop entry removal (not Linux)${NC}"
+	echo -e "${GRAY}[2/3] Skipping desktop entry removal (not Linux)${NC}"
 fi
 
 # Remove user data
@@ -71,21 +71,21 @@ MODELS_DIR="$HOME/.cache/huggingface/hub"
 
 # Remove config
 if [ -d "$CONFIG_DIR" ]; then
-    rm -rf "$CONFIG_DIR"
-    echo -e "${GREEN}     Removed config directory${NC}"
+	rm -rf "$CONFIG_DIR"
+	echo -e "${GREEN}     Removed config directory${NC}"
 else
-    echo -e "${GRAY}     Config directory not found${NC}"
+	echo -e "${GRAY}     Config directory not found${NC}"
 fi
 
 # Remove cached models
 INTERPRETER_MODELS=$(find "$MODELS_DIR" -maxdepth 1 -type d -name "models--bquenin--*" 2>/dev/null || true)
 if [ -n "$INTERPRETER_MODELS" ]; then
-    echo "$INTERPRETER_MODELS" | while read -r model; do
-        rm -rf "$model"
-        echo -e "${GREEN}     Removed $(basename "$model")${NC}"
-    done
+	echo "$INTERPRETER_MODELS" | while read -r model; do
+		rm -rf "$model"
+		echo -e "${GREEN}     Removed $(basename "$model")${NC}"
+	done
 else
-    echo -e "${GRAY}     Cached models not found${NC}"
+	echo -e "${GRAY}     Cached models not found${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Use `xdg-icon-resource` for installing/uninstalling the application icon on Linux, with a fallback to manual copy for systems without it
- Format shell scripts with `shfmt`

This ensures the icon is properly registered with the desktop environment's icon theme system, which fixes icon display issues on some Linux distributions.

Fixes #215