### PR TITLE
Update pipewire-capture to 0.2.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     # Linux only - window capture (X11 fallback)
     "python-xlib>=0.33; sys_platform == 'linux'",
     # Linux only - window capture (Wayland via PipeWire portal)
-    "pipewire-capture>=0.2.8; sys_platform == 'linux'",
+    "pipewire-capture>=0.2.9; sys_platform == 'linux'",
     # GPU acceleration (CUDA 12) - Windows and Linux
     "nvidia-cublas-cu12; sys_platform == 'win32' or sys_platform == 'linux'",
     "nvidia-cudnn-cu12; sys_platform == 'win32' or sys_platform == 'linux'",

--- a/uv.lock
+++ b/uv.lock
@@ -323,7 +323,7 @@ requires-dist = [
     { name = "onnxruntime" },
     { name = "opencv-python" },
     { name = "pillow", specifier = ">=10.0.0" },
-    { name = "pipewire-capture", marker = "sys_platform == 'linux'", specifier = ">=0.2.8" },
+    { name = "pipewire-capture", marker = "sys_platform == 'linux'", specifier = ">=0.2.9" },
     { name = "pygetwindow", marker = "sys_platform == 'win32'", specifier = ">=0.0.9" },
     { name = "pynput", marker = "sys_platform == 'darwin' or sys_platform == 'win32'", specifier = ">=1.7.0" },
     { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'", specifier = ">=12.1" },
@@ -544,14 +544,14 @@ wheels = [
 
 [[package]]
 name = "pipewire-capture"
-version = "0.2.8"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/fc/29512ba49491a333dd14c9970236bad49ad3362daf6c56afe62fda28457a/pipewire_capture-0.2.8-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:a566d5f09c4708fbf709a2b8147c84ca2b51dfa44d25e0e412a5e8bd3c4970b4", size = 2454036, upload-time = "2026-01-19T09:33:16.525Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c0/e1f5bd546021c6f333744b976502ea0aea30f4365aff8a5e8c98888a8adc/pipewire_capture-0.2.8-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:86307c74968549861f6d4620f58fd8a7fd620077467134300bbaa8923512d298", size = 2464254, upload-time = "2026-01-19T09:33:18.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c9/e35061a330eb1bda41ef3b8cada55a71643b8e55edfb75d939c27bfe3fc3/pipewire_capture-0.2.9-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e16ae134a072adf006d7f9e32a20669a003312b6ee8611b2d1f7f1938342d212", size = 2455188, upload-time = "2026-02-01T02:14:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4f/68f11128fdfe83266e95a6b505701d476509a1e7d01aff38cac8de2c2848/pipewire_capture-0.2.9-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:216e506d82f036f21054c7189b47f313e16136505c258cf389febaf98dd92d80", size = 2464126, upload-time = "2026-02-01T02:14:42.903Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `pipewire-capture` from `>=0.2.8` to `>=0.2.9`
- Fixes capture stall on single-buffer PipeWire setups (e.g., Bazzite/KDE)

Closes #219

## Test plan
- [x] Tested on Bazzite Desktop Mode — capture now delivers frames as expected