### PR TITLE
Fix crash in Bazzite Game Mode

### DIFF
--- a/src/interpreter/gui/app.py
+++ b/src/interpreter/gui/app.py
@@ -9,9 +9,16 @@ from pathlib import Path
 # On Linux, force Qt to use X11/XWayland instead of native Wayland.
 # This gives us proper stay-on-top behavior for overlay windows.
 # Native Wayland compositors (especially GNOME) don't respect WindowStaysOnTopHint.
+# Exception: gamescope (Steam Deck Game Mode) is a Wayland compositor where XWayland
+# may not be accessible, so we must let Qt use Wayland natively.
 # Must be set BEFORE importing Qt.
 if platform.system() == "Linux" and "QT_QPA_PLATFORM" not in os.environ:
-    os.environ["QT_QPA_PLATFORM"] = "xcb"
+    _is_gamescope = (
+        os.getenv("XDG_CURRENT_DESKTOP", "").lower() == "gamescope"
+        or bool(os.getenv("GAMESCOPE_WAYLAND_DISPLAY"))
+    )
+    if not _is_gamescope:
+        os.environ["QT_QPA_PLATFORM"] = "xcb"
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon


### PR DESCRIPTION
## Summary
- Skip `QT_QPA_PLATFORM=xcb` override when running under gamescope (Steam Deck Game Mode)
- Gamescope is a Wayland compositor where XWayland may not be accessible, causing Qt to fail to initialize and the app to immediately exit
- Detection uses `XDG_CURRENT_DESKTOP=gamescope` and `GAMESCOPE_WAYLAND_DISPLAY` env vars

Closes #214

## Test plan
- [x] Verified app still starts correctly in Desktop Mode (xcb override still applied)
- [ ] Test in Bazzite Game Mode — app should launch instead of immediately closing