### PR TITLE
Bump version to 2.17.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "interpreter-v2"
-version = "2.17.1"
+version = "2.17.2"
 description = "Offline screen translator for Japanese retro games"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"


### PR DESCRIPTION
## Summary
- Bump version to 2.17.2 for release including pipewire-capture 0.2.9 update (fixes capture stall on single-buffer PipeWire setups)