### PR TITLE
Fix install/uninstall on Windows when uv registry is out of sync

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -34,7 +34,7 @@ Write-Host "     (this may take a minute on first install)" -ForegroundColor Gra
 # Use Python 3.12 explicitly - onnxruntime doesn't have wheels for 3.14 yet
 # Temporarily allow errors so uv's progress output (on stderr) doesn't stop the script
 $ErrorActionPreference = 'Continue'
-uv tool install --upgrade --python 3.12 interpreter-v2
+uv tool install --force --upgrade --python 3.12 interpreter-v2
 $installExitCode = $LASTEXITCODE
 $ErrorActionPreference = 'Stop'
 if ($installExitCode -ne 0) {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -19,13 +19,31 @@ $toolList = uv tool list 2>$null
 if ($toolList -notmatch "interpreter-v2") {
     Write-Host "interpreter-v2 is not installed." -ForegroundColor Yellow
 } else {
-    Write-Host "[1/2] Uninstalling interpreter-v2..." -ForegroundColor Yellow
+    Write-Host "[1/3] Uninstalling interpreter-v2..." -ForegroundColor Yellow
     uv tool uninstall interpreter-v2
     Write-Host "interpreter-v2 uninstalled" -ForegroundColor Green
 }
 
+# Remove orphan executable and stale tool environment left behind after a
+# broken Python reinstall — uv tool list may no longer know about them.
+Write-Host "[2/3] Cleaning up orphan files..." -ForegroundColor Yellow
+$orphanExe = "$env:USERPROFILE\.local\bin\interpreter-v2.exe"
+if (Test-Path $orphanExe) {
+    Remove-Item -Force $orphanExe
+    Write-Host "     Removed orphan executable" -ForegroundColor Green
+} else {
+    Write-Host "     No orphan executable found" -ForegroundColor Gray
+}
+$staleToolDir = "$env:LOCALAPPDATA\uv\tools\interpreter-v2"
+if (Test-Path $staleToolDir) {
+    Remove-Item -Recurse -Force $staleToolDir
+    Write-Host "     Removed stale tool environment" -ForegroundColor Green
+} else {
+    Write-Host "     No stale tool environment found" -ForegroundColor Gray
+}
+
 # Remove user data
-Write-Host "[2/2] Removing user data..." -ForegroundColor Yellow
+Write-Host "[3/3] Removing user data..." -ForegroundColor Yellow
 
 $configDir = "$env:USERPROFILE\.interpreter"
 $modelsDir = "$env:USERPROFILE\.cache\huggingface\hub"


### PR DESCRIPTION
## Summary
- `install.ps1`: pass `--force` to `uv tool install` so reinstalling over an orphan `interpreter-v2.exe` shim succeeds instead of failing with `Executable already exists`.
- `uninstall.ps1`: added a cleanup step that removes the orphan shim (`%USERPROFILE%\.local\bin\interpreter-v2.exe`) and stale tool env (`%LOCALAPPDATA%\uv\tools\interpreter-v2\`) directly, so uninstall works even after `uv tool list` has forgotten about the tool (e.g. after a Python reinstall).

Fixes #228.

## Test plan
- [ ] Simulate the broken state: leave `~\.local\bin\interpreter-v2.exe` in place while `uv tool list` is empty, then run `install.ps1` — install completes cleanly instead of erroring.
- [ ] Run `uninstall.ps1` from the same broken state — orphan exe and stale tool dir are removed, step labels show `[1/3] [2/3] [3/3]`.
- [ ] Happy path: run `install.ps1` on a clean machine, confirm it still installs and runs `interpreter-v2 --list-windows` at the end.
- [ ] Happy path: run `uninstall.ps1` on a normally-installed machine, confirm config and HF model cache are still removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)