### PR TITLE
Include nameless windows in Windows capture list

### DIFF
--- a/src/interpreter/capture/windows.py
+++ b/src/interpreter/capture/windows.py
@@ -189,31 +189,64 @@ class BITMAPINFO(ctypes.Structure):
     ]
 
 
+def _is_window_cloaked(hwnd: int) -> bool:
+    """Check if a window is cloaked by DWM.
+
+    UWP and modern apps leave behind hidden 'ghost' top-level windows that
+    still enumerate via EnumWindows but are invisible to the user.
+    """
+    DWMWA_CLOAKED = 14
+    cloaked = wintypes.DWORD(0)
+    hr = ctypes.windll.dwmapi.DwmGetWindowAttribute(
+        wintypes.HWND(hwnd),
+        ctypes.c_uint(DWMWA_CLOAKED),
+        ctypes.byref(cloaked),
+        ctypes.sizeof(cloaked),
+    )
+    return hr == 0 and cloaked.value != 0
+
+
 def get_window_list() -> list[dict]:
-    """Get list of all windows with their properties.
+    """Get list of all top-level capturable windows.
+
+    Nameless windows (e.g. some RPGMaker games that leave Game.ini Title=
+    empty) are included with a synthetic label so users can still select
+    them. Invisible, cloaked, and zero-size windows are filtered out.
 
     Returns:
-        List of window dictionaries with keys: id, title, bounds
+        List of window dictionaries with keys: id, title, owner, bounds
     """
     if not WINDOWS_AVAILABLE:
         return []
 
+    user32 = ctypes.windll.user32
+    shell_hwnd = user32.GetShellWindow()
+
     windows = []
     for win in gw.getAllWindows():
-        if win.title:  # Skip windows without titles
-            windows.append(
-                {
-                    "id": win._hWnd,
-                    "title": win.title,
-                    "owner": "",
-                    "bounds": {
-                        "x": win.left,
-                        "y": win.top,
-                        "width": win.width,
-                        "height": win.height,
-                    },
-                }
-            )
+        hwnd = win._hWnd
+        if hwnd == shell_hwnd:
+            continue
+        if not user32.IsWindowVisible(hwnd):
+            continue
+        if win.width <= 0 or win.height <= 0:
+            continue
+        if _is_window_cloaked(hwnd):
+            continue
+        title = win.title or f"[Untitled window {hex(hwnd)}]"
+        windows.append(
+            {
+                "id": hwnd,
+                "title": title,
+                "owner": "",
+                "bounds": {
+                    "x": win.left,
+                    "y": win.top,
+                    "width": win.width,
+                    "height": win.height,
+                },
+            }
+        )
     return windows
 
 


### PR DESCRIPTION
## Summary
- Some RPGMaker games ship with `Game.ini`'s `Title=` empty, so their window has a blank title. `get_window_list()` was filtering those out with `if win.title:`, making them unpickable in the GUI even though Win32 capture by HWND works fine.
- Replace the title-based filter with standard visibility heuristics (skip shell window, invisible, zero-size, DWM-cloaked UWP ghosts). Nameless windows are kept and given a synthetic label like `[Untitled window 0x1013c]` so they remain selectable.

Fixes #226.

## Test plan
- [x] Smoke-tested `get_window_list()` locally on Windows 11 — nameless window appears with synthetic label; titled windows unchanged; list length went from 2 to 3 on my session.
- [ ] Launch a title-less RPGMaker game and confirm it now appears in the GUI's window combo and captures correctly.
- [ ] Confirm UWP ghost windows (e.g. Settings remnants after closing) don't pollute the list.
- [ ] Confirm the desktop / shell window doesn't appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)