### PR TITLE
Fix uv tool directory path on Windows (%APPDATA%, not %LOCALAPPDATA%)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -51,7 +51,7 @@ $ErrorActionPreference = 'Stop'
 
 # Pre-compile bytecode and warm up OS caches
 Write-Host "[3/3] Optimizing for fast startup..." -ForegroundColor Yellow
-$toolDir = "$env:LOCALAPPDATA\uv\tools\interpreter-v2"
+$toolDir = "$env:APPDATA\uv\tools\interpreter-v2"
 if (Test-Path $toolDir) {
     & "$toolDir\Scripts\python.exe" -m compileall -q "$toolDir\Lib" 2>$null
     # Warm up caches (Windows Defender, etc.) by running once

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -34,7 +34,7 @@ if (Test-Path $orphanExe) {
 } else {
     Write-Host "     No orphan executable found" -ForegroundColor Gray
 }
-$staleToolDir = "$env:LOCALAPPDATA\uv\tools\interpreter-v2"
+$staleToolDir = "$env:APPDATA\uv\tools\interpreter-v2"
 if (Test-Path $staleToolDir) {
     Remove-Item -Recurse -Force $staleToolDir
     Write-Host "     Removed stale tool environment" -ForegroundColor Green


### PR DESCRIPTION
## Summary
`uv` installs tools to `%APPDATA%\uv\tools\` (Roaming) on Windows — confirmed via `uv tool dir`. Two spots in the PowerShell scripts had this wrong:

- **`install.ps1:54`** — the `[3/3] Optimizing for fast startup...` block (bytecode precompile + capture warm-up) has been silently no-oping since `Test-Path` on the wrong path always returned `False`. Now actually runs.
- **`uninstall.ps1:37`** — the orphan stale-tool-env cleanup added in #230 was looking at the wrong path, so the scenario from #228 (Python reinstall breaks uv's registry, leaves behind a tool env) wouldn't have been fully cleaned up in practice. Now removes the real stale env.

Scripts are fetched fresh from `main` on each run, so no release is needed.

## Test plan
- [x] Confirmed `uv tool dir` reports `%APPDATA%\uv\tools` on local Windows 11 machine.
- [x] Confirmed the previously-wrong path `%LOCALAPPDATA%\uv\tools\interpreter-v2` does not exist, while the corrected `%APPDATA%\uv\tools\interpreter-v2` does.
- [ ] Re-run `install.ps1` on this machine and confirm the `[3/3]` block actually executes `python -m compileall` and `interpreter-v2 --list-windows` (previously skipped silently).
- [ ] Simulate the #228 broken-install state (delete the uv tool registry entry but leave the tool env on disk) and confirm `uninstall.ps1` now removes the orphan directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)