### PR TITLE
Fix install.ps1 warm-up command (--list-windows → --help)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -54,8 +54,9 @@ Write-Host "[3/3] Optimizing for fast startup..." -ForegroundColor Yellow
 $toolDir = "$env:APPDATA\uv\tools\interpreter-v2"
 if (Test-Path $toolDir) {
     & "$toolDir\Scripts\python.exe" -m compileall -q "$toolDir\Lib" 2>$null
-    # Warm up caches (Windows Defender, etc.) by running once
-    & interpreter-v2 --list-windows 2>$null | Out-Null
+    # Warm up caches (Windows Defender, etc.) by triggering the full
+    # module-level import chain via --help (no GUI, exits cleanly).
+    & interpreter-v2 --help 2>$null | Out-Null
 }
 
 Write-Host ""


### PR DESCRIPTION
## Summary
The `[3/3] Optimizing for fast startup...` block in `install.ps1` invoked `interpreter-v2 --list-windows`, but that flag doesn't exist in the CLI (see `src/interpreter/gui/app.py:128-129` — only `--debug` is defined). argparse rejected the unknown argument with exit code 2, which leaked out as the whole installer's exit code.

This was hidden for a while because #232's `%LOCALAPPDATA%` → `%APPDATA%` fix revealed that the entire `[3/3]` block had been silently no-oping. With the path now correct, the broken warm-up surfaced immediately.

Switch the warm-up to `--help`. It still triggers the same module-level import chain (PySide6 → `main_window` → OCR/translation modules), so Windows Defender still scans everything once, but exits cleanly with status 0 and doesn't open a window.

Scripts are served from `main`, so no release is needed.

## Test plan
- [x] Reproduced the original failure locally: `interpreter-v2 --list-windows` returns exit 2 with `unrecognized arguments: --list-windows`.
- [ ] Re-run `install.ps1` post-merge and confirm it exits 0.
- [ ] Confirm `interpreter-v2 --help` exits 0 and prints the usage string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)