### PR TITLE
Use process name in nameless-window labels

### DIFF
--- a/src/interpreter/capture/windows.py
+++ b/src/interpreter/capture/windows.py
@@ -206,12 +206,42 @@ def _is_window_cloaked(hwnd: int) -> bool:
     return hr == 0 and cloaked.value != 0
 
 
+def _get_window_process_name(hwnd: int) -> str | None:
+    """Get the owning process's executable basename (no extension).
+
+    Used to give nameless windows a more identifiable label — e.g.
+    RPGMaker games typically ship as 'Game.exe' so the user sees
+    'Game' instead of an opaque HWND. Returns None on failure.
+    """
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    pid = wintypes.DWORD(0)
+    ctypes.windll.user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    if pid.value == 0:
+        return None
+
+    handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid.value)
+    if not handle:
+        return None
+    try:
+        buf = ctypes.create_unicode_buffer(1024)
+        size = wintypes.DWORD(len(buf))
+        if not ctypes.windll.kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+            return None
+        name = buf.value.rsplit("\\", 1)[-1]
+        if name.lower().endswith(".exe"):
+            name = name[:-4]
+        return name or None
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)
+
+
 def get_window_list() -> list[dict]:
     """Get list of all top-level capturable windows.
 
     Nameless windows (e.g. some RPGMaker games that leave Game.ini Title=
-    empty) are included with a synthetic label so users can still select
-    them. Invisible, cloaked, and zero-size windows are filtered out.
+    empty) are labeled with the owning process name and HWND so users can
+    still identify and select them. Invisible, cloaked, and zero-size
+    windows are filtered out.
 
     Returns:
         List of window dictionaries with keys: id, title, owner, bounds
@@ -233,7 +263,10 @@ def get_window_list() -> list[dict]:
             continue
         if _is_window_cloaked(hwnd):
             continue
-        title = win.title or f"[Untitled window {hex(hwnd)}]"
+        title = win.title
+        if not title:
+            proc = _get_window_process_name(hwnd)
+            title = f"{proc} ({hex(hwnd)})" if proc else f"[Untitled window {hex(hwnd)}]"
         windows.append(
             {
                 "id": hwnd,


### PR DESCRIPTION
## Summary
`[Untitled window 0x1013c]` tells the user nothing — just an opaque HWND. Resolve the owning process via `GetWindowThreadProcessId` + `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `QueryFullProcessImageNameW`, strip to the executable basename without extension, and use that in the label.

Before → after on my local session:
- `[Untitled window 0x1013c] (1280x48)` → `explorer (0x1013c) (1280x48)`

For the RPGMaker games that OP in #226 was trying to capture (typically shipping as `Game.exe`), they'll now see `Game (0x1234)` — actually useful. For custom-named game exes it'll be even more identifiable (e.g. `MyAwesomeGame (0x1234)`).

Falls back to the previous `[Untitled window 0xHWND]` label if the process query fails (e.g. process is a protected system process and `OpenProcess` is denied).

Follows up on #231.

## Test plan
- [x] Smoke-tested locally: previously-nameless window now shows as `explorer (0x1013c)`, correctly identifying a Windows Explorer subwindow.
- [ ] Launch a title-less RPGMaker game; confirm label shows `Game (0xHWND)` or the actual exe basename.
- [ ] Confirm titled windows are unchanged (process lookup is only invoked when `win.title` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)