### PR TITLE
Force TLS 1.2 in install.ps1 for Windows PowerShell 5.1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -3,6 +3,10 @@
 
 $ErrorActionPreference = 'Stop'
 
+# Force TLS 1.2+ for Windows PowerShell 5.1, which defaults to TLS 1.0/1.1
+# and fails against modern hosts like astral.sh.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 Write-Host ""
 Write-Host "=== interpreter-v2 Installer ===" -ForegroundColor Cyan
 Write-Host "Offline screen translator for Japanese retro games"


### PR DESCRIPTION
## Summary
- Windows PowerShell 5.1 defaults to TLS 1.0/1.1, which fails against modern hosts like `astral.sh` (where `uv`'s installer lives), producing "The underlying connection was closed: An unexpected error occurred on a send".
- This adds a single line at the top of `install.ps1` that bitwise-ORs `Tls12` into the security protocol, additively enabling TLS 1.2 without disabling whatever was already enabled.
- No-op on PowerShell 7+ (TLS 1.2/1.3 already enabled by default).

Fixes #235.

## Test plan
- [ ] Run the one-liner on a stock Windows 10/11 box using `powershell` (Windows PowerShell 5.1) and confirm the uv installer downloads successfully.
- [ ] Run the one-liner on PowerShell 7 (`pwsh`) and confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)