### PR TITLE
Detect missing libxcb-cursor in Linux installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Offline screen translator for Japanese retro games. Captures text from any windo
 - **Global hotkeys** require `input` group membership. The installer will show instructions.
 - **Native Wayland capture** requires GStreamer PipeWire plugin. The installer will attempt to install it automatically.
 - **Inplace overlay** on Wayland only works with fullscreen windows (Wayland's security model prevents knowing window positions).
+- **Qt platform plugin** (`xcb`) requires `libxcb-cursor0` (Debian/Ubuntu/Mint) or `xcb-util-cursor` (Fedora/Arch). Without it the GUI will abort with `Could not load the Qt platform plugin "xcb"`.
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -66,10 +66,10 @@ if [ -d "$TOOL_DIR" ]; then
 	interpreter-v2 --list-windows >/dev/null 2>&1 || true
 fi
 
-# Check Wayland dependencies (Linux only)
+# Check Linux runtime dependencies (Linux only)
 # Always check regardless of WAYLAND_DISPLAY - some compositors like gamescope don't set it
 if [[ "$(uname)" == "Linux" ]]; then
-	echo -e "${YELLOW}[4/${TOTAL_STEPS}] Checking Wayland capture dependencies...${NC}"
+	echo -e "${YELLOW}[4/${TOTAL_STEPS}] Checking Linux runtime dependencies...${NC}"
 
 	if ldconfig -p 2>/dev/null | grep -q libpipewire-0.3; then
 		echo -e "${GREEN}     PipeWire library available${NC}"
@@ -78,6 +78,16 @@ if [[ "$(uname)" == "Linux" ]]; then
 		echo -e "${GRAY}     Install with: apt install libpipewire-0.3-0 (Debian/Ubuntu)${NC}"
 		echo -e "${GRAY}                   dnf install pipewire (Fedora)${NC}"
 		echo -e "${GRAY}                   pacman -S pipewire (Arch)${NC}"
+	fi
+
+	# Qt 6.5+ requires libxcb-cursor for the xcb platform plugin used on X11/XWayland.
+	if ldconfig -p 2>/dev/null | grep -q libxcb-cursor; then
+		echo -e "${GREEN}     libxcb-cursor available${NC}"
+	else
+		echo -e "${YELLOW}     libxcb-cursor not found. The GUI may fail to launch on X11/XWayland.${NC}"
+		echo -e "${GRAY}     Install with: apt install libxcb-cursor0 (Debian/Ubuntu/Mint)${NC}"
+		echo -e "${GRAY}                   dnf install xcb-util-cursor (Fedora)${NC}"
+		echo -e "${GRAY}                   pacman -S xcb-util-cursor (Arch)${NC}"
 	fi
 fi
 


### PR DESCRIPTION
## Summary
- Add a check in `install.sh` for `libxcb-cursor`, alongside the existing PipeWire check, with per-distro install hints.
- Document the requirement in the README's Linux Notes.

Qt 6.5+ requires `libxcb-cursor` for the `xcb` platform plugin used on X11/XWayland. Without it PySide6 aborts with `Could not load the Qt platform plugin "xcb"` and the GUI never launches (e.g. on Linux Mint, as reported in #236).

Fixes #236

## Test plan
- [ ] Run `install.sh` on a Linux box without `libxcb-cursor0` installed and confirm the warning prints with the apt/dnf/pacman hints.
- [ ] Run `install.sh` on a Linux box with `libxcb-cursor0` installed and confirm the green "available" line prints.
- [ ] Run `install.sh` on macOS and confirm the new check is skipped (Linux-only block).