### PR TITLE
Add offline Chinese->English translation support and improved inplace layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # Interpreter
 
-Offline screen translator for Japanese and Chinese games. Captures text from any window, performs OCR, translates to English, and displays subtitles in a floating overlay.
+Play Japanese and Chinese games with live English translation.
+
+Interpreter captures in-game text from any window, runs OCR locally, translates it offline, and overlays clean English subtitles so you can play import titles without ROM hacks or cloud APIs.
 
 ![screenshot](screenshot.png)
+
+Caption: The original game screen stays intact while Interpreter reads the dialogue box and shows an English subtitle overlay in real time.
+
+## Why use it?
+
+- Play untranslated retro RPGs without fan patches
+- Keep your emulator setup and original game visuals unchanged
+- Run fully offline after model download
+- Switch between Japanese -> English and Chinese -> English in the GUI
 
 ## Features
 
@@ -74,7 +85,7 @@ This opens the GUI where you can select a window to capture and configure all se
 A subtitle bar at the bottom of the screen displaying translated text. Draggable, opaque background, centered text.
 
 ### Inplace Mode
-Transparent overlay positioned over the game window. Translated text appears directly over the original Japanese text at OCR-detected positions. Click-through so you can interact with the game.
+Transparent overlay positioned over the game window. Translated text appears directly over the original Japanese or Chinese text at OCR-detected positions. Click-through so you can interact with the game.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Interpreter
 
-Offline screen translator for Japanese retro games. Captures text from any window, performs OCR, translates to English, and displays subtitles in a floating overlay.
+Offline screen translator for Japanese and Chinese games. Captures text from any window, performs OCR, translates to English, and displays subtitles in a floating overlay.
 
 ![screenshot](screenshot.png)
 
@@ -9,7 +9,8 @@ Offline screen translator for Japanese retro games. Captures text from any windo
 - **Fully offline** - No cloud APIs, no internet required after setup
 - **Free** - No API costs or subscriptions
 - **Private** - Text never leaves your machine
-- **Optimized for retro games** - Uses MeikiOCR, trained specifically on Japanese game text
+- **Japanese and Chinese support** - Select Japanese -> English or Chinese -> English
+- **Optimized for retro games** - Uses MeikiOCR for Japanese game text and RapidOCR for Chinese text
 - **Two overlay modes** - Banner (subtitle bar) or inplace (text over game)
 - **Translation caching** - Fuzzy matching avoids re-translating similar text
 - **Multi-display support** - Overlay appears on the same display as the game
@@ -78,8 +79,8 @@ Transparent overlay positioned over the game window. Translated text appears dir
 ## How It Works
 
 1. **Screen Capture** - Captures the target window at the configured refresh rate
-2. **OCR** - [MeikiOCR](https://github.com/rtr46/meikiocr) extracts Japanese text (optimized for pixel fonts)
-3. **Translation** - [Sugoi V4](https://huggingface.co/entai2965/sugoi-v4-ja-en-ctranslate2) translates Japanese to English
+2. **OCR** - [MeikiOCR](https://github.com/rtr46/meikiocr) extracts Japanese text (optimized for pixel fonts), while [RapidOCR](https://github.com/RapidAI/RapidOCR) handles Chinese text
+3. **Translation** - [Sugoi V4](https://huggingface.co/entai2965/sugoi-v4-ja-en-ctranslate2) translates Japanese to English, while [OPUS-MT zh-en](https://huggingface.co/gaudi/opus-mt-zh-en-ctranslate2) translates Chinese to English
 4. **Display** - Shows translated text in the selected overlay mode
 
 ## Troubleshooting
@@ -89,3 +90,10 @@ Try adjusting the OCR confidence slider in the GUI. Lower values include more te
 
 ### Slow performance
 First run downloads models (~1.5GB). Subsequent runs use cached models from `~/.cache/huggingface/`.
+
+## Language Support
+
+- Japanese -> English: MeikiOCR + Sugoi V4
+- Chinese -> English: RapidOCR + OPUS-MT zh-en
+
+Chinese OCR quality may vary on low-resolution retro pixel fonts and may require OCR confidence tuning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "interpreter-v2"
 version = "2.17.4"
-description = "Offline screen translator for Japanese retro games"
+description = "Offline screen translator for Japanese and Chinese games"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
 license = "MIT"
 authors = [
     { name = "qube" }
 ]
-keywords = ["ocr", "translation", "japanese", "games", "retro"]
+keywords = ["ocr", "translation", "japanese", "chinese", "games", "retro"]
 
 dependencies = [
     # OCR
@@ -17,6 +17,7 @@ dependencies = [
     # Translation (Sugoi V4)
     "ctranslate2",
     "sentencepiece",
+    "transformers",
     # Image processing
     "Pillow>=10.0.0",
     "numpy",
@@ -28,6 +29,8 @@ dependencies = [
     # Model download
     "requests",
     "tqdm",
+    # Chinese OCR
+    "rapidocr",
     # Logging
     "structlog>=24.0.0",
     # macOS only - window capture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "ctranslate2",
     "sentencepiece",
     "transformers",
+    "sacremoses",
     # Image processing
     "Pillow>=10.0.0",
     "numpy",

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -16,6 +16,13 @@ class OverlayMode(str, Enum):
     INPLACE = "inplace"
 
 
+class SourceLanguage(str, Enum):
+    """Source language for OCR and translation."""
+
+    JAPANESE = "japanese"
+    CHINESE = "chinese"
+
+
 logger = log.get_logger()
 
 
@@ -41,6 +48,7 @@ class Config:
         window_title: str = "Snes9x",
         ocr_confidence: float = 0.6,
         overlay_mode: OverlayMode = OverlayMode.BANNER,
+        source_language: SourceLanguage = SourceLanguage.JAPANESE,
         font_family: str | None = None,
         font_size: int = 26,
         font_color: str = "#FFFFFF",
@@ -56,6 +64,7 @@ class Config:
         self.window_title = window_title
         self.ocr_confidence = ocr_confidence  # Global default
         self.overlay_mode = overlay_mode
+        self.source_language = source_language
         self.font_family = font_family  # None = system default
         self.font_size = font_size
         self.font_color = font_color
@@ -112,10 +121,18 @@ class Config:
                 logger.warning("invalid overlay_mode, using banner", mode=mode_str)
                 overlay_mode = OverlayMode.BANNER
 
+            source_language_str = data.get("source_language", SourceLanguage.JAPANESE.value)
+            try:
+                source_language = SourceLanguage(source_language_str)
+            except ValueError:
+                logger.warning("invalid source_language, using japanese", source_language=source_language_str)
+                source_language = SourceLanguage.JAPANESE
+
             return cls(
                 window_title=data.get("window_title", cls.DEFAULT_WINDOW_TITLE),
                 ocr_confidence=float(data.get("ocr_confidence", cls.DEFAULT_OCR_CONFIDENCE)),
                 overlay_mode=overlay_mode,
+                source_language=source_language,
                 font_family=data.get("font_family"),  # None = system default
                 font_size=int(data.get("font_size", 26)),
                 font_color=data.get("font_color", "#FFFFFF"),
@@ -153,6 +170,9 @@ window_title: "Snes9x"
 # OCR confidence threshold (0.0-1.0)
 # Filters out low-confidence text detection
 ocr_confidence: 0.6
+
+# Source language: "japanese" or "chinese"
+source_language: japanese
 
 # Overlay mode: "banner" (subtitle bar) or "inplace" (over game text)
 overlay_mode: banner
@@ -257,6 +277,7 @@ hotkeys:
             "window_title": str(self.window_title) if self.window_title else "",
             "ocr_confidence": float(self.ocr_confidence),
             "overlay_mode": self.overlay_mode.value,
+            "source_language": self.source_language.value,
             "font_size": int(self.font_size),
             "font_color": str(self.font_color),
             "background_color": str(self.background_color),

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -39,6 +39,17 @@ def get_active_translation_model_name(source_language: SourceLanguage) -> str:
     return "Sugoi V4"
 
 
+def normalize_source_language(source_language: SourceLanguage | str) -> SourceLanguage:
+    """Normalize a source language enum or string value."""
+    if isinstance(source_language, SourceLanguage):
+        return source_language
+    try:
+        return SourceLanguage(source_language)
+    except ValueError:
+        logger.warning("invalid source_language, using japanese", source_language=source_language)
+        return SourceLanguage.JAPANESE
+
+
 class Config:
     """Application configuration."""
 
@@ -77,7 +88,7 @@ class Config:
         self.window_title = window_title
         self.ocr_confidence = ocr_confidence  # Global default
         self.overlay_mode = overlay_mode
-        self.source_language = source_language
+        self.source_language = normalize_source_language(source_language)
         self.font_family = font_family  # None = system default
         self.font_size = font_size
         self.font_color = font_color
@@ -290,7 +301,7 @@ hotkeys:
             "window_title": str(self.window_title) if self.window_title else "",
             "ocr_confidence": float(self.ocr_confidence),
             "overlay_mode": self.overlay_mode.value,
-            "source_language": self.source_language.value,
+            "source_language": normalize_source_language(self.source_language).value,
             "font_size": int(self.font_size),
             "font_color": str(self.font_color),
             "background_color": str(self.background_color),

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -25,6 +25,19 @@ class SourceLanguage(str, Enum):
 
 logger = log.get_logger()
 
+def get_active_ocr_model_name(source_language: SourceLanguage) -> str:
+    """Return the active OCR model name for a source language."""
+    if source_language == SourceLanguage.CHINESE:
+        return "RapidOCR"
+    return "MeikiOCR"
+
+
+def get_active_translation_model_name(source_language: SourceLanguage) -> str:
+    """Return the active translation model name for a source language."""
+    if source_language == SourceLanguage.CHINESE:
+        return "OPUS-MT zh-en"
+    return "Sugoi V4"
+
 
 class Config:
     """Application configuration."""

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -25,7 +25,13 @@ from PySide6.QtWidgets import (
 from .. import log
 from ..capture import Capture, WindowCapture, _is_wayland_session
 from ..capture.convert import bgra_to_rgb_pil
-from ..config import Config, OverlayMode, SourceLanguage
+from ..config import (
+    Config,
+    OverlayMode,
+    SourceLanguage,
+    get_active_ocr_model_name,
+    get_active_translation_model_name,
+)
 from ..overlay import BannerOverlay, InplaceOverlay
 from ..permissions import (
     check_accessibility,
@@ -349,13 +355,15 @@ class MainWindow(QMainWindow):
 
         # OCR model row
         status_layout.addWidget(QLabel("OCR:"), 0, 0)
-        status_layout.addWidget(QLabel("MeikiOCR"), 0, 1)
+        self._ocr_model_name_label = QLabel()
+        status_layout.addWidget(self._ocr_model_name_label, 0, 1)
         self._ocr_status_label = QLabel("Loading...")
         status_layout.addWidget(self._ocr_status_label, 0, 2)
 
         # Translation model row
         status_layout.addWidget(QLabel("Translation:"), 1, 0)
-        status_layout.addWidget(QLabel("Sugoi V4"), 1, 1)
+        self._translation_model_name_label = QLabel()
+        status_layout.addWidget(self._translation_model_name_label, 1, 1)
         self._translation_status_label = QLabel("Loading...")
         status_layout.addWidget(self._translation_status_label, 1, 2)
 
@@ -371,6 +379,7 @@ class MainWindow(QMainWindow):
 
         # Set column stretch so status is right-aligned
         status_layout.setColumnStretch(1, 1)
+        self._update_active_model_labels()
 
         layout.addWidget(status_group)
 
@@ -492,7 +501,21 @@ class MainWindow(QMainWindow):
         self._source_language = source_language
         self._config.source_language = source_language
         self._config.save()
+        self._update_active_model_labels()
         self._restart_process_worker()
+
+    def _update_active_model_labels(self):
+        """Update the status area to show the active OCR/translation models."""
+        ocr_name = get_active_ocr_model_name(self._source_language)
+        translation_name = get_active_translation_model_name(self._source_language)
+        self._ocr_model_name_label.setText(f"{ocr_name} (active)")
+        self._translation_model_name_label.setText(f"{translation_name} (active)")
+        self._ocr_model_name_label.setToolTip(
+            "Japanese uses MeikiOCR. Chinese uses RapidOCR. The active pipeline follows the Language selector."
+        )
+        self._translation_model_name_label.setToolTip(
+            "Japanese uses Sugoi V4. Chinese uses OPUS-MT zh-en. The active pipeline follows the Language selector."
+        )
 
     def _on_models_ready(self):
         """Handle models loaded signal from worker thread."""
@@ -544,8 +567,8 @@ class MainWindow(QMainWindow):
             label.setText("Downloading...")
             label.setStyleSheet("")
         elif status == "ready":
-            label.setText("Ready")
-            label.setStyleSheet("color: green;")
+            label.setText("● Active")
+            label.setStyleSheet("color: green; font-weight: 600;")
         elif status == "error":
             label.setText("Error")
             label.setStyleSheet("color: red;")

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -31,6 +31,7 @@ from ..config import (
     SourceLanguage,
     get_active_ocr_model_name,
     get_active_translation_model_name,
+    normalize_source_language,
 )
 from ..overlay import BannerOverlay, InplaceOverlay
 from ..permissions import (
@@ -494,7 +495,7 @@ class MainWindow(QMainWindow):
 
     def _on_source_language_changed(self, index: int):
         """Handle source language selection change."""
-        source_language = self._language_combo.itemData(index)
+        source_language = normalize_source_language(self._language_combo.itemData(index))
         if source_language == self._source_language:
             return
 

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
 from .. import log
 from ..capture import Capture, WindowCapture, _is_wayland_session
 from ..capture.convert import bgra_to_rgb_pil
-from ..config import Config, OverlayMode
+from ..config import Config, OverlayMode, SourceLanguage
 from ..overlay import BannerOverlay, InplaceOverlay
 from ..permissions import (
     check_accessibility,
@@ -66,6 +66,7 @@ class MainWindow(QMainWindow):
         # State
         self._capturing = False
         self._mode = config.overlay_mode
+        self._source_language = config.source_language
         self._windows_list: list[dict] = []
         self._paused = False
         self._current_window_title: str = ""  # For exclusion zone lookup
@@ -196,6 +197,21 @@ class MainWindow(QMainWindow):
         # Overlay mode + all visual settings
         appearance_group = QGroupBox("Appearance")
         appearance_layout = QVBoxLayout(appearance_group)
+
+        # Language row
+        language_row = QHBoxLayout()
+        language_row.addWidget(QLabel("Language:"))
+
+        self._language_combo = QComboBox()
+        self._language_combo.addItem("Japanese -> English", SourceLanguage.JAPANESE)
+        self._language_combo.addItem("Chinese -> English", SourceLanguage.CHINESE)
+        current_language_index = self._language_combo.findData(self._source_language)
+        if current_language_index >= 0:
+            self._language_combo.setCurrentIndex(current_language_index)
+        self._language_combo.currentIndexChanged.connect(self._on_source_language_changed)
+        language_row.addWidget(self._language_combo)
+        language_row.addStretch()
+        appearance_layout.addLayout(language_row)
 
         # Mode row (Banner/Inplace toggle + hotkeys)
         mode_row = QHBoxLayout()
@@ -450,7 +466,33 @@ class MainWindow(QMainWindow):
         """Start worker thread and load OCR/translation models."""
         self.statusBar().showMessage("Loading models...")
         self._process_worker.set_mode(self._mode)
+        self._process_worker.set_source_language(self._source_language)
         self._process_worker.start(self._config.ocr_confidence)
+
+    def _restart_process_worker(self):
+        """Recreate the worker and reload models."""
+        self._process_worker.stop()
+        self._process_worker = ProcessWorker()
+        self._process_worker.text_ready.connect(self._on_text_ready)
+        self._process_worker.regions_ready.connect(self._on_regions_ready)
+        self._process_worker.models_ready.connect(self._on_models_ready)
+        self._process_worker.models_failed.connect(self._on_models_failed)
+        self._process_worker.ocr_status.connect(self._on_ocr_status)
+        self._process_worker.translation_status.connect(self._on_translation_status)
+        self._process_worker.set_mode(self._mode)
+        self._process_worker.set_source_language(self._source_language)
+        self._process_worker.start(self._config.ocr_confidence)
+
+    def _on_source_language_changed(self, index: int):
+        """Handle source language selection change."""
+        source_language = self._language_combo.itemData(index)
+        if source_language == self._source_language:
+            return
+
+        self._source_language = source_language
+        self._config.source_language = source_language
+        self._config.save()
+        self._restart_process_worker()
 
     def _on_models_ready(self):
         """Handle models loaded signal from worker thread."""
@@ -516,6 +558,7 @@ class MainWindow(QMainWindow):
     def _on_fix_models(self):
         """Handle Fix Models button click."""
         from ..models import delete_model_cache
+        from ..translate import get_translation_repo_id
 
         # Track which models we're fixing (to show "Downloading..." instead of "Loading...")
         self._fixing_ocr = False
@@ -523,12 +566,12 @@ class MainWindow(QMainWindow):
 
         # Delete caches for failed models
         failed = self._process_worker.get_failed_models()
-        if "ocr" in failed:
+        if "ocr" in failed and self._source_language == SourceLanguage.JAPANESE:
             delete_model_cache("rtr46/meiki.text.detect.v0")
             delete_model_cache("rtr46/meiki.txt.recognition.v0")
             self._fixing_ocr = True
         if "translation" in failed:
-            delete_model_cache("entai2965/sugoi-v4-ja-en-ctranslate2")
+            delete_model_cache(get_translation_repo_id(self._source_language))
             self._fixing_translation = True
 
         # Hide the button while fixing
@@ -536,16 +579,7 @@ class MainWindow(QMainWindow):
         self.statusBar().showMessage("Downloading models...")
 
         # Stop and restart the worker to reload models
-        self._process_worker.stop()
-        self._process_worker = ProcessWorker()
-        self._process_worker.text_ready.connect(self._on_text_ready)
-        self._process_worker.regions_ready.connect(self._on_regions_ready)
-        self._process_worker.models_ready.connect(self._on_models_ready)
-        self._process_worker.models_failed.connect(self._on_models_failed)
-        self._process_worker.ocr_status.connect(self._on_ocr_status)
-        self._process_worker.translation_status.connect(self._on_translation_status)
-        self._process_worker.set_mode(self._mode)
-        self._process_worker.start(self._config.ocr_confidence)
+        self._restart_process_worker()
 
     def _refresh_windows(self):
         """Refresh the window list (X11 only)."""

--- a/src/interpreter/gui/workers.py
+++ b/src/interpreter/gui/workers.py
@@ -6,7 +6,7 @@ import time
 from PySide6.QtCore import QObject, Signal
 
 from .. import log
-from ..config import OverlayMode
+from ..config import OverlayMode, SourceLanguage
 from ..ocr import OCR
 from ..translate import Translator
 
@@ -17,16 +17,21 @@ def contains_japanese(text: str) -> bool:
     """Check if text contains Japanese characters."""
     for char in text:
         code = ord(char)
-        # Hiragana: U+3040-U+309F
-        # Katakana: U+30A0-U+30FF
-        # CJK (Kanji): U+4E00-U+9FFF
-        # Half-width Katakana: U+FF65-U+FF9F
         if (
-            0x3040 <= code <= 0x309F  # Hiragana
-            or 0x30A0 <= code <= 0x30FF  # Katakana
-            or 0x4E00 <= code <= 0x9FFF  # Kanji
-            or 0xFF65 <= code <= 0xFF9F  # Half-width Katakana
+            0x3040 <= code <= 0x309F
+            or 0x30A0 <= code <= 0x30FF
+            or 0x4E00 <= code <= 0x9FFF
+            or 0xFF65 <= code <= 0xFF9F
         ):
+            return True
+    return False
+
+
+def contains_han(text: str) -> bool:
+    """Check if text contains CJK unified ideographs."""
+    for char in text:
+        code = ord(char)
+        if 0x4E00 <= code <= 0x9FFF:
             return True
     return False
 
@@ -97,6 +102,7 @@ class ProcessWorker(QObject):
         self._ocr: OCR | None = None
         self._translator: Translator | None = None
         self._mode = OverlayMode.BANNER
+        self._source_language = SourceLanguage.JAPANESE
         self._confidence_threshold = 0.6
 
         # Track which models failed (for "Fix Models" button)
@@ -111,6 +117,10 @@ class ProcessWorker(QObject):
     def set_mode(self, mode: OverlayMode):
         """Set the overlay mode."""
         self._mode = mode
+
+    def set_source_language(self, source_language: SourceLanguage):
+        """Set source language for OCR and translation."""
+        self._source_language = source_language
 
     def set_confidence_threshold(self, threshold: float):
         """Set the OCR confidence threshold."""
@@ -157,7 +167,7 @@ class ProcessWorker(QObject):
         # Load OCR model
         self.ocr_status.emit("loading")
         try:
-            self._ocr = OCR(confidence_threshold=self._confidence_threshold)
+            self._ocr = OCR(confidence_threshold=self._confidence_threshold, source_language=self._source_language)
             self._ocr.load()
             self._ocr_failed = False
             self.ocr_status.emit("ready")
@@ -170,7 +180,7 @@ class ProcessWorker(QObject):
         # Load translation model
         self.translation_status.emit("loading")
         try:
-            self._translator = Translator()
+            self._translator = Translator(source_language=self._source_language)
             self._translator.load()
             self._translation_failed = False
             self.translation_status.emit("ready")
@@ -228,9 +238,14 @@ class ProcessWorker(QObject):
                 self.text_ready.emit("")
             return
 
-        # Skip translation for non-Japanese text
-        if not contains_japanese(text):
-            logger.debug("skipping translation - no Japanese characters detected")
+        should_translate = True
+        if self._source_language == SourceLanguage.JAPANESE:
+            should_translate = contains_japanese(text)
+        elif self._source_language == SourceLanguage.CHINESE:
+            should_translate = bool(text.strip()) and contains_han(text)
+
+        if not should_translate:
+            logger.debug("skipping translation - text does not match active source language")
             if self._mode == OverlayMode.INPLACE:
                 self.regions_ready.emit([])
             else:
@@ -244,10 +259,15 @@ class ProcessWorker(QObject):
             all_cached = True
             for region in regions:
                 if self._translator and region.text:
-                    # Skip non-Japanese regions
-                    if not contains_japanese(region.text):
+                    if self._source_language == SourceLanguage.JAPANESE and not contains_japanese(region.text):
                         logger.debug(
                             "skipping region - no Japanese characters",
+                            text=region.text[:30],
+                        )
+                        continue
+                    if self._source_language == SourceLanguage.CHINESE and not contains_han(region.text):
+                        logger.debug(
+                            "skipping region - no Chinese characters",
                             text=region.text[:30],
                         )
                         continue

--- a/src/interpreter/ocr.py
+++ b/src/interpreter/ocr.py
@@ -6,7 +6,13 @@ import numpy as np
 from numpy.typing import NDArray
 
 from . import log
-from .capture.convert import bgra_to_rgb
+from .config import SourceLanguage
+
+
+def bgra_to_rgb(frame: NDArray[np.uint8]) -> NDArray[np.uint8]:
+    """Convert BGRA numpy array to RGB numpy array."""
+    rgb = frame[:, :, [2, 1, 0]]
+    return np.ascontiguousarray(rgb)
 
 logger = log.get_logger()
 
@@ -28,7 +34,7 @@ class OCRResult:
     bbox: dict | None = None  # {"x": int, "y": int, "width": int, "height": int}
 
 
-class OCR:
+class JapaneseOCR:
     """Extracts Japanese text from images using MeikiOCR.
 
     MeikiOCR is specifically trained on Japanese video game text,
@@ -330,3 +336,40 @@ class OCR:
             True if model is loaded, False otherwise.
         """
         return self._model is not None
+
+
+class OCR:
+    """Language-aware OCR wrapper."""
+
+    def __init__(
+        self,
+        confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+        debug: bool = False,
+        source_language: SourceLanguage = SourceLanguage.JAPANESE,
+    ):
+        if source_language == SourceLanguage.CHINESE:
+            from .ocr_rapid import ChineseOCR
+
+            self._backend = ChineseOCR(confidence_threshold=confidence_threshold, debug=debug)
+        else:
+            self._backend = JapaneseOCR(confidence_threshold=confidence_threshold, debug=debug)
+
+    @property
+    def confidence_threshold(self) -> float:
+        return self._backend.confidence_threshold
+
+    @confidence_threshold.setter
+    def confidence_threshold(self, value: float) -> None:
+        self._backend.confidence_threshold = value
+
+    def load(self) -> None:
+        self._backend.load()
+
+    def extract_text(self, image: NDArray[np.uint8]) -> str:
+        return self._backend.extract_text(image)
+
+    def extract_text_regions(self, image: NDArray[np.uint8]) -> list[OCRResult]:
+        return self._backend.extract_text_regions(image)
+
+    def is_loaded(self) -> bool:
+        return self._backend.is_loaded()

--- a/src/interpreter/ocr_rapid.py
+++ b/src/interpreter/ocr_rapid.py
@@ -1,0 +1,105 @@
+"""Chinese OCR backend using RapidOCR."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from . import log
+from .ocr import DEFAULT_CONFIDENCE_THRESHOLD, OCRResult
+
+logger = log.get_logger()
+
+
+def bgra_to_rgb(frame: NDArray[np.uint8]) -> NDArray[np.uint8]:
+    """Convert BGRA numpy array to RGB numpy array."""
+    rgb = frame[:, :, [2, 1, 0]]
+    return np.ascontiguousarray(rgb)
+
+
+class ChineseOCR:
+    """Extracts Chinese text from images using RapidOCR."""
+
+    def __init__(self, confidence_threshold: float = DEFAULT_CONFIDENCE_THRESHOLD, debug: bool = False):
+        self._engine = None
+        self._confidence_threshold = confidence_threshold
+        self._debug = debug
+
+    @property
+    def confidence_threshold(self) -> float:
+        return self._confidence_threshold
+
+    @confidence_threshold.setter
+    def confidence_threshold(self, value: float) -> None:
+        self._confidence_threshold = value
+
+    def load(self) -> None:
+        if self._engine is not None:
+            return
+
+        logger.info("loading rapidocr")
+        from rapidocr import RapidOCR
+
+        self._engine = RapidOCR()
+        logger.info("rapidocr ready")
+
+    def _quad_to_bbox(self, box) -> dict | None:
+        if box is None or len(box) == 0:
+            return None
+
+        xs = [int(point[0]) for point in box]
+        ys = [int(point[1]) for point in box]
+        min_x = min(xs)
+        min_y = min(ys)
+        max_x = max(xs)
+        max_y = max(ys)
+
+        if min_x < 0 or min_y < 0 or max_x <= min_x or max_y <= min_y:
+            return None
+
+        return {
+            "x": min_x,
+            "y": min_y,
+            "width": max_x - min_x,
+            "height": max_y - min_y,
+        }
+
+    def _run_ocr(self, image: NDArray[np.uint8]) -> list[OCRResult]:
+        if self._engine is None:
+            self.load()
+
+        img_array = bgra_to_rgb(image)
+        output = self._engine(img_array)
+
+        if not output or getattr(output, "boxes", None) is None or getattr(output, "txts", None) is None:
+            return []
+
+        scores = getattr(output, "scores", None)
+        if scores is None:
+            scores = [1.0] * len(output.txts)
+
+        results = []
+        for box, text, score in zip(output.boxes, output.txts, scores, strict=False):
+            text = (text or "").strip()
+            if not text:
+                continue
+            if score is not None and score < self._confidence_threshold:
+                if self._debug:
+                    logger.debug("rapidocr rejected", text=text, score=score)
+                continue
+
+            bbox = self._quad_to_bbox(box)
+            if bbox is None:
+                continue
+
+            results.append(OCRResult(text=text, bbox=bbox))
+
+        results.sort(key=lambda region: (region.bbox["y"], region.bbox["x"]))
+        return results
+
+    def extract_text(self, image: NDArray[np.uint8]) -> str:
+        return " ".join(region.text for region in self._run_ocr(image) if region.text)
+
+    def extract_text_regions(self, image: NDArray[np.uint8]) -> list[OCRResult]:
+        return self._run_ocr(image)
+
+    def is_loaded(self) -> bool:
+        return self._engine is not None

--- a/src/interpreter/ocr_rapid.py
+++ b/src/interpreter/ocr_rapid.py
@@ -1,5 +1,7 @@
 """Chinese OCR backend using RapidOCR."""
 
+import logging
+
 import numpy as np
 from numpy.typing import NDArray
 
@@ -36,9 +38,10 @@ class ChineseOCR:
             return
 
         logger.info("loading rapidocr")
+        logging.getLogger("RapidOCR").setLevel(logging.WARNING)
         from rapidocr import RapidOCR
 
-        self._engine = RapidOCR()
+        self._engine = RapidOCR(params={"Global.log_level": "WARNING"})
         logger.info("rapidocr ready")
 
     def _quad_to_bbox(self, box) -> dict | None:

--- a/src/interpreter/overlay/base.py
+++ b/src/interpreter/overlay/base.py
@@ -42,8 +42,11 @@ def arrange_overlay_regions(
     content_offset_x = int(content_offset[0] / scale)
     content_offset_y = int(content_offset[1] / scale)
 
+    ordered_pairs = list(zip(regions, label_sizes, strict=False))
+    ordered_pairs.sort(key=lambda item: (-item[0][1].get("x", 0), item[0][1].get("y", 0)))
+
     arranged: list[dict] = []
-    for (text, bbox), (label_width, label_height) in zip(regions, label_sizes, strict=False):
+    for (text, bbox), (label_width, label_height) in ordered_pairs:
         if not bbox:
             continue
 

--- a/src/interpreter/overlay/base.py
+++ b/src/interpreter/overlay/base.py
@@ -21,6 +21,49 @@ BANNER_VERTICAL_PADDING = 30
 # Qt maximum widget size (not exposed in PySide6, defined as (1 << 24) - 1 in C++)
 QWIDGETSIZE_MAX = 16777215
 
+def _rects_overlap(a: dict, b: dict) -> bool:
+    """Return True when two label rectangles overlap."""
+    return not (
+        a["x"] + a["label_width"] <= b["x"]
+        or b["x"] + b["label_width"] <= a["x"]
+        or a["y"] + a["label_height"] <= b["y"]
+        or b["y"] + b["label_height"] <= a["y"]
+    )
+
+
+def arrange_overlay_regions(
+    regions: list[tuple[str, dict]],
+    label_sizes: list[tuple[int, int]],
+    scale: float,
+    content_offset: tuple[int, int] = (0, 0),
+    padding: int = 4,
+) -> list[dict]:
+    """Arrange overlay labels to avoid overlapping translated regions."""
+    content_offset_x = int(content_offset[0] / scale)
+    content_offset_y = int(content_offset[1] / scale)
+
+    arranged: list[dict] = []
+    for (text, bbox), (label_width, label_height) in zip(regions, label_sizes, strict=False):
+        if not bbox:
+            continue
+
+        item = {
+            "text": text,
+            "bbox": bbox,
+            "x": int(bbox.get("x", 0) / scale) + content_offset_x,
+            "y": int(bbox.get("y", 0) / scale) + content_offset_y,
+            "label_width": label_width,
+            "label_height": label_height,
+        }
+
+        while any(_rects_overlap(item, existing) for existing in arranged):
+            overlapping = [existing for existing in arranged if _rects_overlap(item, existing)]
+            item["y"] = max(existing["y"] + existing["label_height"] + padding for existing in overlapping)
+
+        arranged.append(item)
+
+    return arranged
+
 
 class BannerOverlayBase(QWidget):
     """Banner-style overlay at bottom of screen.
@@ -336,6 +379,7 @@ class InplaceOverlayBase(QWidget):
         self._clear_labels()
 
         # Create new labels
+        label_entries: list[tuple[QLabel, str, dict]] = []
         for text, bbox in regions:
             if not bbox:
                 continue
@@ -352,12 +396,17 @@ class InplaceOverlayBase(QWidget):
                 "border-radius: 4px;"
             )
             label.adjustSize()
-            # Position at bbox location, converting from pixels to points
-            # OCR returns coordinates in captured image pixels (physical pixels)
-            # Qt uses logical pixels (points), so divide by scale factor
-            x = int(bbox.get("x", 0) / scale) + content_offset_x
-            y = int(bbox.get("y", 0) / scale) + content_offset_y
-            label.move(x, y)
+            label_entries.append((label, text, bbox))
+
+        arranged = arrange_overlay_regions(
+            [(text, bbox) for _, text, bbox in label_entries],
+            [(label.width(), label.height()) for label, _, _ in label_entries],
+            scale=scale,
+            content_offset=content_offset,
+        )
+
+        for (label, _, _), layout in zip(label_entries, arranged, strict=False):
+            label.move(layout["x"], layout["y"])
             label.show()
             self._labels.append(label)
 

--- a/src/interpreter/translate.py
+++ b/src/interpreter/translate.py
@@ -1,13 +1,17 @@
 """Translation module for offline Japanese and Chinese to English."""
 
+import logging
 import os
 import sys
+import warnings
 from difflib import SequenceMatcher
 from pathlib import Path
 
 # Suppress HuggingFace Hub warnings (must be set before import)
 os.environ["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
 os.environ["HF_HUB_VERBOSITY"] = "error"
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
 
 from . import log
 from .config import SourceLanguage
@@ -205,7 +209,14 @@ class ChineseTranslator:
         logger.info("loading opus zh-en")
 
         import ctranslate2
-        from transformers import AutoTokenizer
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="Recommended: pip install sacremoses\.", category=UserWarning)
+            from transformers import AutoTokenizer
+            from transformers.utils import logging as transformers_logging
+
+        logging.getLogger("transformers").setLevel(logging.ERROR)
+        transformers_logging.set_verbosity_error()
 
         required_files = ["model.bin", "source.spm", "target.spm"]
         self._model_path = _get_model_path(OPUS_ZH_EN_REPO_ID, required_files, download_size="~155MB")
@@ -214,14 +225,14 @@ class ChineseTranslator:
         try:
             cuda_types = ctranslate2.get_supported_compute_types("cuda")
             if cuda_types:
-                self._translator = ctranslate2.Translator(str(self._model_path), device="cuda")
+                self._translator = ctranslate2.Translator(str(self._model_path), device="cuda", compute_type="float16")
                 self._translator.translate_batch([["▁测试", "</s>"]])
                 device = "cuda"
         except Exception as e:
             logger.debug("CUDA failed, falling back to CPU", error=str(e))
 
         if device == "cpu":
-            self._translator = ctranslate2.Translator(str(self._model_path), device="cpu")
+            self._translator = ctranslate2.Translator(str(self._model_path), device="cpu", compute_type="float32")
 
         self._tokenizer = AutoTokenizer.from_pretrained(self._model_path)
         logger.info("opus zh-en ready", device=("GPU" if device == "cuda" else "CPU"))

--- a/src/interpreter/translate.py
+++ b/src/interpreter/translate.py
@@ -1,50 +1,46 @@
-"""Translation module using Sugoi V4 for offline Japanese to English."""
+"""Translation module for offline Japanese and Chinese to English."""
 
 import os
 import sys
+from difflib import SequenceMatcher
+from pathlib import Path
 
 # Suppress HuggingFace Hub warnings (must be set before import)
 os.environ["HF_HUB_DISABLE_IMPLICIT_TOKEN"] = "1"
 os.environ["HF_HUB_VERBOSITY"] = "error"
 
-from difflib import SequenceMatcher
-from pathlib import Path
-
-from huggingface_hub import snapshot_download
-from huggingface_hub.utils import LocalEntryNotFoundError
-
 from . import log
+from .config import SourceLanguage
 from .models import ModelLoadError
 
 logger = log.get_logger()
 
-# Official HuggingFace repository for Sugoi V4
 SUGOI_REPO_ID = "entai2965/sugoi-v4-ja-en-ctranslate2"
+OPUS_ZH_EN_REPO_ID = "gaudi/opus-mt-zh-en-ctranslate2"
 
-# Required files that must exist for the model to work
 REQUIRED_MODEL_FILES = [
     "model.bin",
     "spm/spm.ja.nopretok.model",
 ]
 
-# Translation cache defaults
-DEFAULT_CACHE_SIZE = 200  # Max cached translations
-DEFAULT_SIMILARITY_THRESHOLD = 0.9  # Fuzzy match threshold for cache lookup
+DEFAULT_CACHE_SIZE = 200
+DEFAULT_SIMILARITY_THRESHOLD = 0.9
+
+
+def _snapshot_download(*args, **kwargs):
+    from huggingface_hub import snapshot_download
+
+    return snapshot_download(*args, **kwargs)
+
+
+def _get_local_entry_not_found_error():
+    from huggingface_hub.utils import LocalEntryNotFoundError
+
+    return LocalEntryNotFoundError
 
 
 def _get_short_path(path: Path) -> str:
-    """Convert path to Windows short (8.3) format to handle non-ASCII characters.
-
-    CTranslate2 and SentencePiece (C++ libraries) may fail to load files from paths
-    containing non-ASCII characters on Windows. This function converts paths to the
-    short 8.3 format which only uses ASCII characters.
-
-    Args:
-        path: Path to convert.
-
-    Returns:
-        Short path string on Windows if conversion succeeds, otherwise original path string.
-    """
+    """Convert path to Windows short (8.3) format to handle non-ASCII characters."""
     if sys.platform == "win32":
         import ctypes
 
@@ -54,60 +50,35 @@ def _get_short_path(path: Path) -> str:
     return str(path)
 
 
-def _validate_model_files(model_path: Path) -> bool:
-    """Check if all required model files exist.
-
-    Args:
-        model_path: Path to the model directory.
-
-    Returns:
-        True if all required files exist, False otherwise.
-    """
-    for file_path in REQUIRED_MODEL_FILES:
+def _validate_model_files(model_path: Path, required_files: list[str]) -> bool:
+    for file_path in required_files:
         if not (model_path / file_path).exists():
             logger.warning("missing model file", file=file_path)
             return False
     return True
 
 
-def _get_sugoi_model_path() -> Path:
-    """Get path to Sugoi V4 translation model, downloading if needed.
+def _get_model_path(repo_id: str, required_files: list[str], download_size: str | None = None) -> Path:
+    """Get path to a Hugging Face model, downloading if needed."""
+    local_entry_not_found_error = _get_local_entry_not_found_error()
 
-    Downloads from official HuggingFace source on first use.
-    Model is cached in standard HuggingFace cache (~/.cache/huggingface/).
-
-    Returns:
-        Path to the model directory.
-
-    Raises:
-        ModelLoadError: If model files are missing or corrupted.
-    """
-    # First try to load from cache (no network request)
     try:
-        model_path = snapshot_download(
-            repo_id=SUGOI_REPO_ID,
-            local_files_only=True,
-        )
+        model_path = _snapshot_download(repo_id=repo_id, local_files_only=True)
         model_path = Path(model_path)
-        # Validate that required files exist
-        if _validate_model_files(model_path):
+        if _validate_model_files(model_path, required_files):
             return model_path
-        # Files missing - raise error (UI will show "Fix Models" button)
-        raise ModelLoadError(
-            "Translation model cache is corrupted. Click 'Fix Models' to repair."
-        )
-    except LocalEntryNotFoundError:
+        raise ModelLoadError("Model cache is corrupted. Click 'Fix Models' to repair.")
+    except local_entry_not_found_error:
         pass
 
-    # Not cached, download from HuggingFace
-    logger.info("downloading sugoi v4 model", size="~1.1GB")
-    model_path = Path(snapshot_download(repo_id=SUGOI_REPO_ID))
+    log_fields = {"repo": repo_id}
+    if download_size:
+        log_fields["size"] = download_size
+    logger.info("downloading translation model", **log_fields)
+    model_path = Path(_snapshot_download(repo_id=repo_id))
 
-    # Validate download completed successfully
-    if not _validate_model_files(model_path):
-        raise ModelLoadError(
-            "Translation model download incomplete. Click 'Fix Models' to retry."
-        )
+    if not _validate_model_files(model_path, required_files):
+        raise ModelLoadError("Translation model download incomplete. Click 'Fix Models' to retry.")
 
     return model_path
 
@@ -127,30 +98,14 @@ class TranslationCache:
         max_size: int = DEFAULT_CACHE_SIZE,
         similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
     ):
-        """Initialize the cache.
-
-        Args:
-            max_size: Maximum number of entries to store.
-            similarity_threshold: Minimum similarity ratio for fuzzy match (0.0-1.0).
-        """
         self._cache: dict[str, str] = {}
         self._max_size = max_size
         self._similarity_threshold = similarity_threshold
 
     def get(self, text: str) -> str | None:
-        """Get cached translation, using fuzzy matching if exact match not found.
-
-        Args:
-            text: Japanese text to look up.
-
-        Returns:
-            Cached translation if found, None otherwise.
-        """
-        # Try exact match first
         if text in self._cache:
             return self._cache[text]
 
-        # Try fuzzy match
         for cached_text, translation in self._cache.items():
             if text_similarity(text, cached_text) >= self._similarity_threshold:
                 return translation
@@ -158,13 +113,6 @@ class TranslationCache:
         return None
 
     def put(self, text: str, translation: str) -> None:
-        """Store a translation in the cache.
-
-        Args:
-            text: Japanese source text.
-            translation: English translation.
-        """
-        # Simple LRU: remove oldest entry if at capacity
         if len(self._cache) >= self._max_size and text not in self._cache:
             oldest_key = next(iter(self._cache))
             del self._cache[oldest_key]
@@ -172,7 +120,7 @@ class TranslationCache:
         self._cache[text] = translation
 
 
-class Translator:
+class JapaneseTranslator:
     """Translates Japanese text to English using Sugoi V4 (CTranslate2)."""
 
     def __init__(
@@ -180,23 +128,12 @@ class Translator:
         cache_size: int = DEFAULT_CACHE_SIZE,
         similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
     ):
-        """Initialize the translator (lazy loading).
-
-        Args:
-            cache_size: Maximum number of translations to cache.
-            similarity_threshold: Minimum similarity for fuzzy cache match (0.0-1.0).
-        """
         self._model_path = None
         self._translator = None
         self._tokenizer = None
         self._cache = TranslationCache(cache_size, similarity_threshold)
 
     def load(self) -> None:
-        """Load the translation model, downloading if needed.
-
-        Raises:
-            ModelLoadError: If model fails to load.
-        """
         if self._translator is not None:
             return
 
@@ -205,104 +142,155 @@ class Translator:
         import ctranslate2
         import sentencepiece as spm
 
-        # Get model path (downloads from HuggingFace if needed)
-        self._model_path = _get_sugoi_model_path()
+        self._model_path = _get_model_path(SUGOI_REPO_ID, REQUIRED_MODEL_FILES, download_size="~1.1GB")
 
-        # Load CTranslate2 model with GPU if available, fallback to CPU
         device = "cpu"
         try:
             cuda_types = ctranslate2.get_supported_compute_types("cuda")
             if cuda_types:
-                # Try to load with GPU
-                self._translator = ctranslate2.Translator(
-                    _get_short_path(self._model_path),
-                    device="cuda",
-                )
-                # Test inference to verify CUDA actually works
-                # (loading may succeed but inference can fail if cuBLAS is missing)
+                self._translator = ctranslate2.Translator(_get_short_path(self._model_path), device="cuda")
                 self._translator.translate_batch([["テスト"]])
                 device = "cuda"
         except Exception as e:
-            # GPU failed (load or inference), will use CPU below
             logger.debug("CUDA failed, falling back to CPU", error=str(e))
 
         if device == "cpu":
-            self._translator = ctranslate2.Translator(
-                _get_short_path(self._model_path),
-                device="cpu",
-            )
+            self._translator = ctranslate2.Translator(_get_short_path(self._model_path), device="cpu")
 
-        # Load SentencePiece tokenizer
-        # Read model as bytes to avoid Unicode path issues on Windows
-        # (SentencePiece's C++ layer may not handle non-ASCII paths correctly)
         tokenizer_path = self._model_path / "spm" / "spm.ja.nopretok.model"
         self._tokenizer = spm.SentencePieceProcessor(model_proto=tokenizer_path.read_bytes())
 
-        device_info = "GPU" if device == "cuda" else "CPU"
-        logger.info("sugoi v4 ready", device=device_info)
+        logger.info("sugoi v4 ready", device=("GPU" if device == "cuda" else "CPU"))
 
     def translate(self, text: str) -> tuple[str, bool]:
-        """Translate Japanese text to English.
-
-        Args:
-            text: Japanese text to translate.
-
-        Returns:
-            Tuple of (translated English text, was_cached).
-        """
         if not text or not text.strip():
             return "", False
 
-        # Check cache first (includes fuzzy matching)
         cached = self._cache.get(text)
         if cached is not None:
             return cached, True
 
-        # Ensure model is loaded
         if self._translator is None:
             self.load()
 
-        # Tokenize input
         tokens = self._tokenizer.EncodeAsPieces(text)
-
-        # Translate
-        results = self._translator.translate_batch(
-            [tokens],
-            beam_size=5,
-            max_decoding_length=256,
-        )
-
-        # Decode output - join tokens and clean up SentencePiece markers
+        results = self._translator.translate_batch([tokens], beam_size=5, max_decoding_length=256)
         translated_tokens = results[0].hypotheses[0]
         result = "".join(translated_tokens).replace("▁", " ").strip()
-
-        # Normalize Unicode characters to ASCII equivalents (fixes rendering issues)
-        result = (
-            result
-            # Curly quotes → straight quotes
-            .replace("\u2018", "'")  # LEFT SINGLE QUOTATION MARK
-            .replace("\u2019", "'")  # RIGHT SINGLE QUOTATION MARK
-            .replace("\u201c", '"')  # LEFT DOUBLE QUOTATION MARK
-            .replace("\u201d", '"')  # RIGHT DOUBLE QUOTATION MARK
-            # Dashes
-            .replace("\u2013", "-")  # EN DASH
-            .replace("\u2014", "--")  # EM DASH
-            .replace("\u2212", "-")  # MINUS SIGN
-            # Spaces
-            .replace("\u00a0", " ")  # NO-BREAK SPACE
-            # Ellipsis
-            .replace("\u2026", "...")  # HORIZONTAL ELLIPSIS
-        )
-
-        # Store in cache
+        result = normalize_translation_text(result)
         self._cache.put(text, result)
-
         return result, False
 
     def is_loaded(self) -> bool:
-        """Check if the translation model is loaded.
-
-        Returns:
-            True if model is loaded, False otherwise.
-        """
         return self._translator is not None
+
+
+class ChineseTranslator:
+    """Translates Chinese text to English using OPUS-MT (CTranslate2)."""
+
+    def __init__(
+        self,
+        cache_size: int = DEFAULT_CACHE_SIZE,
+        similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    ):
+        self._model_path = None
+        self._translator = None
+        self._tokenizer = None
+        self._cache = TranslationCache(cache_size, similarity_threshold)
+
+    def load(self) -> None:
+        if self._translator is not None:
+            return
+
+        logger.info("loading opus zh-en")
+
+        import ctranslate2
+        from transformers import AutoTokenizer
+
+        required_files = ["model.bin", "source.spm", "target.spm"]
+        self._model_path = _get_model_path(OPUS_ZH_EN_REPO_ID, required_files, download_size="~155MB")
+
+        device = "cpu"
+        try:
+            cuda_types = ctranslate2.get_supported_compute_types("cuda")
+            if cuda_types:
+                self._translator = ctranslate2.Translator(str(self._model_path), device="cuda")
+                self._translator.translate_batch([["▁测试", "</s>"]])
+                device = "cuda"
+        except Exception as e:
+            logger.debug("CUDA failed, falling back to CPU", error=str(e))
+
+        if device == "cpu":
+            self._translator = ctranslate2.Translator(str(self._model_path), device="cpu")
+
+        self._tokenizer = AutoTokenizer.from_pretrained(self._model_path)
+        logger.info("opus zh-en ready", device=("GPU" if device == "cuda" else "CPU"))
+
+    def translate(self, text: str) -> tuple[str, bool]:
+        if not text or not text.strip():
+            return "", False
+
+        cached = self._cache.get(text)
+        if cached is not None:
+            return cached, True
+
+        if self._translator is None:
+            self.load()
+
+        input_ids = self._tokenizer.encode(text)
+        tokens = self._tokenizer.convert_ids_to_tokens(input_ids)
+        results = self._translator.translate_batch([tokens], beam_size=4, max_decoding_length=256)
+        translated_tokens = results[0].hypotheses[0]
+        translated_ids = self._tokenizer.convert_tokens_to_ids(translated_tokens)
+        result = self._tokenizer.decode(translated_ids, skip_special_tokens=True).strip()
+        result = normalize_translation_text(result)
+        self._cache.put(text, result)
+        return result, False
+
+    def is_loaded(self) -> bool:
+        return self._translator is not None
+
+
+def normalize_translation_text(result: str) -> str:
+    return (
+        result
+        .replace("‘", "'")
+        .replace("’", "'")
+        .replace("“", '"')
+        .replace("”", '"')
+        .replace("–", "-")
+        .replace("—", "--")
+        .replace("−", "-")
+        .replace(" ", " ")
+        .replace("…", "...")
+    )
+
+
+class Translator:
+    """Language-aware translation wrapper."""
+
+    def __init__(
+        self,
+        source_language: SourceLanguage = SourceLanguage.JAPANESE,
+        cache_size: int = DEFAULT_CACHE_SIZE,
+        similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    ):
+        if source_language == SourceLanguage.CHINESE:
+            self._backend = ChineseTranslator(cache_size, similarity_threshold)
+        else:
+            self._backend = JapaneseTranslator(cache_size, similarity_threshold)
+
+    def load(self) -> None:
+        self._backend.load()
+
+    def translate(self, text: str) -> tuple[str, bool]:
+        return self._backend.translate(text)
+
+    def is_loaded(self) -> bool:
+        return self._backend.is_loaded()
+
+
+def get_translation_repo_id(source_language: SourceLanguage) -> str:
+    if source_language == SourceLanguage.CHINESE:
+        return OPUS_ZH_EN_REPO_ID
+    return SUGOI_REPO_ID

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,3 +56,16 @@ def test_config_save_round_trips_source_language(tmp_path):
 
     assert loaded.source_language == SourceLanguage.CHINESE
     assert "source_language: chinese" in Path(config_path).read_text(encoding="utf-8")
+
+
+def test_active_model_names_match_source_language():
+    from interpreter.config import (
+        SourceLanguage,
+        get_active_ocr_model_name,
+        get_active_translation_model_name,
+    )
+
+    assert get_active_ocr_model_name(SourceLanguage.JAPANESE) == "MeikiOCR"
+    assert get_active_ocr_model_name(SourceLanguage.CHINESE) == "RapidOCR"
+    assert get_active_translation_model_name(SourceLanguage.JAPANESE) == "Sugoi V4"
+    assert get_active_translation_model_name(SourceLanguage.CHINESE) == "OPUS-MT zh-en"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+"""Tests for config source language support."""
+
+import importlib.metadata
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import importlib.metadata
+
+_real_version = importlib.metadata.version
+
+
+def _version_with_fallback(name: str) -> str:
+    if name == "interpreter-v2":
+        return "0.0"
+    return _real_version(name)
+
+
+importlib.metadata.version = _version_with_fallback
+
+
+def test_config_loads_source_language_from_yaml(tmp_path):
+    from interpreter.config import Config, SourceLanguage
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text('source_language: chinese\n', encoding="utf-8")
+
+    config = Config.load(str(config_path))
+
+    assert config.source_language == SourceLanguage.CHINESE
+
+
+def test_config_invalid_source_language_falls_back_to_japanese(tmp_path):
+    from interpreter.config import Config, SourceLanguage
+
+    config_path = tmp_path / "config.yml"
+    config_path.write_text('source_language: klingon\n', encoding="utf-8")
+
+    config = Config.load(str(config_path))
+
+    assert config.source_language == SourceLanguage.JAPANESE
+
+
+def test_config_save_round_trips_source_language(tmp_path):
+    from interpreter.config import Config, SourceLanguage
+
+    config_path = tmp_path / "config.yml"
+    config = Config(source_language=SourceLanguage.CHINESE)
+
+    config.save(str(config_path))
+    loaded = Config.load(str(config_path))
+
+    assert loaded.source_language == SourceLanguage.CHINESE
+    assert "source_language: chinese" in Path(config_path).read_text(encoding="utf-8")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,3 +69,17 @@ def test_active_model_names_match_source_language():
     assert get_active_ocr_model_name(SourceLanguage.CHINESE) == "RapidOCR"
     assert get_active_translation_model_name(SourceLanguage.JAPANESE) == "Sugoi V4"
     assert get_active_translation_model_name(SourceLanguage.CHINESE) == "OPUS-MT zh-en"
+
+
+
+def test_config_save_accepts_string_source_language(tmp_path):
+    from interpreter.config import Config, SourceLanguage
+
+    config_path = tmp_path / "config.yml"
+    config = Config(source_language=SourceLanguage.JAPANESE)
+    config.source_language = "chinese"
+
+    config.save(str(config_path))
+    loaded = Config.load(str(config_path))
+
+    assert loaded.source_language == SourceLanguage.CHINESE

--- a/tests/test_language_backends.py
+++ b/tests/test_language_backends.py
@@ -1,0 +1,97 @@
+"""Tests for language-aware OCR and translation wrappers."""
+
+import importlib.metadata
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import importlib.metadata
+
+_real_version = importlib.metadata.version
+
+
+def _version_with_fallback(name: str) -> str:
+    if name == "interpreter-v2":
+        return "0.0"
+    return _real_version(name)
+
+
+importlib.metadata.version = _version_with_fallback
+
+import types
+
+
+def test_translator_uses_japanese_backend(monkeypatch):
+    from interpreter import translate as translate_module
+    from interpreter.config import SourceLanguage
+
+    class FakeJapaneseTranslator:
+        def __init__(self, *args, **kwargs):
+            self.label = "ja"
+
+    class FakeChineseTranslator:
+        def __init__(self, *args, **kwargs):
+            self.label = "zh"
+
+    monkeypatch.setattr(translate_module, "JapaneseTranslator", FakeJapaneseTranslator)
+    monkeypatch.setattr(translate_module, "ChineseTranslator", FakeChineseTranslator)
+
+    translator = translate_module.Translator(source_language=SourceLanguage.JAPANESE)
+
+    assert translator._backend.label == "ja"
+
+
+def test_translator_uses_chinese_backend(monkeypatch):
+    from interpreter import translate as translate_module
+    from interpreter.config import SourceLanguage
+
+    class FakeJapaneseTranslator:
+        def __init__(self, *args, **kwargs):
+            self.label = "ja"
+
+    class FakeChineseTranslator:
+        def __init__(self, *args, **kwargs):
+            self.label = "zh"
+
+    monkeypatch.setattr(translate_module, "JapaneseTranslator", FakeJapaneseTranslator)
+    monkeypatch.setattr(translate_module, "ChineseTranslator", FakeChineseTranslator)
+
+    translator = translate_module.Translator(source_language=SourceLanguage.CHINESE)
+
+    assert translator._backend.label == "zh"
+
+
+def test_ocr_uses_japanese_backend(monkeypatch):
+    from interpreter import ocr as ocr_module
+    from interpreter.config import SourceLanguage
+
+    class FakeJapaneseOCR:
+        def __init__(self, *args, **kwargs):
+            self.label = "ja"
+
+    monkeypatch.setattr(ocr_module, "JapaneseOCR", FakeJapaneseOCR)
+
+    ocr = ocr_module.OCR(source_language=SourceLanguage.JAPANESE)
+
+    assert ocr._backend.label == "ja"
+
+
+def test_ocr_uses_chinese_backend(monkeypatch):
+    from interpreter import ocr as ocr_module
+    from interpreter.config import SourceLanguage
+
+    class FakeChineseOCR:
+        def __init__(self, *args, **kwargs):
+            self.label = "zh"
+
+    fake_module = types.ModuleType("interpreter.ocr_rapid")
+    fake_module.ChineseOCR = FakeChineseOCR
+    monkeypatch.setitem(sys.modules, "interpreter.ocr_rapid", fake_module)
+
+    ocr = ocr_module.OCR(source_language=SourceLanguage.CHINESE)
+
+    assert ocr._backend.label == "zh"

--- a/tests/test_overlay_layout.py
+++ b/tests/test_overlay_layout.py
@@ -32,10 +32,11 @@ def test_stack_overlapping_regions_moves_second_label_down():
 
     arranged = arrange_overlay_regions(regions, label_sizes, scale=1.0, content_offset=(0, 0), padding=4)
 
-    assert arranged[0]["x"] == 10
-    assert arranged[0]["y"] == 10
-    assert arranged[1]["x"] == 20
-    assert arranged[1]["y"] >= arranged[0]["y"] + arranged[0]["label_height"] + 4
+    items = {item["text"]: item for item in arranged}
+    assert items["Second"]["x"] == 20
+    assert items["Second"]["y"] == 15
+    assert items["First"]["x"] == 10
+    assert items["First"]["y"] >= items["Second"]["y"] + items["Second"]["label_height"] + 4
 
 
 def test_non_overlapping_regions_keep_original_positions():
@@ -49,4 +50,25 @@ def test_non_overlapping_regions_keep_original_positions():
 
     arranged = arrange_overlay_regions(regions, label_sizes, scale=1.0, content_offset=(0, 0), padding=4)
 
-    assert [(item["x"], item["y"]) for item in arranged] == [(10, 10), (200, 10)]
+    positions = {item["text"]: (item["x"], item["y"]) for item in arranged}
+    assert positions == {"Left": (10, 10), "Right": (200, 10)}
+
+
+
+def test_vertical_columns_are_ordered_right_to_left_then_top_to_bottom():
+    from interpreter.overlay.base import arrange_overlay_regions
+
+    regions = [
+        ("left-column", {"x": 100, "y": 10, "width": 20, "height": 60}),
+        ("right-column-top", {"x": 180, "y": 10, "width": 20, "height": 60}),
+        ("right-column-bottom", {"x": 180, "y": 90, "width": 20, "height": 60}),
+    ]
+    label_sizes = [(80, 24), (80, 24), (90, 24)]
+
+    arranged = arrange_overlay_regions(regions, label_sizes, scale=1.0, content_offset=(0, 0), padding=4)
+
+    assert [item["text"] for item in arranged] == [
+        "right-column-top",
+        "right-column-bottom",
+        "left-column",
+    ]

--- a/tests/test_overlay_layout.py
+++ b/tests/test_overlay_layout.py
@@ -1,0 +1,52 @@
+"""Tests for inplace overlay layout helpers."""
+
+import importlib.metadata
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+_real_version = importlib.metadata.version
+
+
+def _version_with_fallback(name: str) -> str:
+    if name == "interpreter-v2":
+        return "0.0"
+    return _real_version(name)
+
+
+importlib.metadata.version = _version_with_fallback
+
+
+def test_stack_overlapping_regions_moves_second_label_down():
+    from interpreter.overlay.base import arrange_overlay_regions
+
+    regions = [
+        ("First", {"x": 10, "y": 10, "width": 40, "height": 20}),
+        ("Second", {"x": 20, "y": 15, "width": 40, "height": 20}),
+    ]
+    label_sizes = [(80, 24), (90, 24)]
+
+    arranged = arrange_overlay_regions(regions, label_sizes, scale=1.0, content_offset=(0, 0), padding=4)
+
+    assert arranged[0]["x"] == 10
+    assert arranged[0]["y"] == 10
+    assert arranged[1]["x"] == 20
+    assert arranged[1]["y"] >= arranged[0]["y"] + arranged[0]["label_height"] + 4
+
+
+def test_non_overlapping_regions_keep_original_positions():
+    from interpreter.overlay.base import arrange_overlay_regions
+
+    regions = [
+        ("Left", {"x": 10, "y": 10, "width": 40, "height": 20}),
+        ("Right", {"x": 200, "y": 10, "width": 40, "height": 20}),
+    ]
+    label_sizes = [(60, 24), (60, 24)]
+
+    arranged = arrange_overlay_regions(regions, label_sizes, scale=1.0, content_offset=(0, 0), padding=4)
+
+    assert [(item["x"], item["y"]) for item in arranged] == [(10, 10), (200, 10)]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,6 +1,27 @@
 """Tests for the translate module."""
 
+import importlib.metadata
 import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import importlib.metadata
+
+_real_version = importlib.metadata.version
+
+
+def _version_with_fallback(name: str) -> str:
+    if name == "interpreter-v2":
+        return "0.0"
+    return _real_version(name)
+
+
+importlib.metadata.version = _version_with_fallback
+
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary
- add Chinese -> English offline mode with RapidOCR + OPUS-MT zh-en
- add language-aware status labels and safer source-language normalization
- improve inplace overlay layout by stacking overlaps and ordering labels for vertical reading flow
- refresh README intro and language support docs

## Testing
- pytest tests -q
- python3.11 -m py_compile src/interpreter/config.py src/interpreter/gui/main_window.py src/interpreter/overlay/base.py
