### PR TITLE
Add reproducible retro-game translation benchmark

### DIFF
--- a/benchmark/translation/.gitignore
+++ b/benchmark/translation/.gitignore
@@ -1,0 +1,4 @@
+data/
+results/
+.cache/
+__pycache__/

--- a/benchmark/translation/README.md
+++ b/benchmark/translation/README.md
@@ -2,6 +2,8 @@
 
 This benchmark compares Japanese-to-English models before any production model is replaced. It keeps model inference, corpus creation, automatic scoring, and human review separate so a candidate cannot influence the test set or grade itself.
 
+The latest reproducible run and decision are recorded in [`RESULTS.md`](RESULTS.md).
+
 The primary workload is the text that a player would actually send from an old Japanese game: kana-heavy writing, unusual spacing, short menu labels, speaker names, punctuation, and longer dialogue. The runner calls the exact production `src/interpreter/translate.py::Translator.translate` implementation for the baseline, including the application's GPU bootstrap and output normalization. It clears the fuzzy translation cache before every measured call so every score and timing measures the model rather than a previous corpus entry.
 
 ## Frozen corpus

--- a/benchmark/translation/README.md
+++ b/benchmark/translation/README.md
@@ -127,7 +127,7 @@ Give reviewers only the CSV. They enter `A`, `B`, `TIE`, or `INVALID`; they shou
   --output benchmark\translation\results\human-ab-scored.json
 ```
 
-The scorer verifies that source text and either translation were not edited after randomization and reports a Wilson 95% interval for decisive preferences. Pass that JSON to `compare --blind-review ...`. Reference verification is a different task and must be blind to all model outputs; create its sheet before results are shown with `reference-packet`.
+The scorer verifies that source text and either translation were not edited after randomization and reports a Wilson 95% interval for decisive preferences. Reviewer-facing CSV cells are exported as text when a spreadsheet could interpret their prefix as a formula; the held key fingerprints both the canonical content and its safe CSV representation. Pass the score JSON to `compare --blind-review ...`. Reference verification is a different task and must be blind to all model outputs; create its sheet before results are shown with `reference-packet`.
 
 ## Production fuzzy-cache diagnostic
 

--- a/benchmark/translation/README.md
+++ b/benchmark/translation/README.md
@@ -1,0 +1,146 @@
+# Translation benchmark
+
+This benchmark compares Japanese-to-English models before any production model is replaced. It keeps model inference, corpus creation, automatic scoring, and human review separate so a candidate cannot influence the test set or grade itself.
+
+The primary workload is the text that a player would actually send from an old Japanese game: kana-heavy writing, unusual spacing, short menu labels, speaker names, punctuation, and longer dialogue. The runner calls the exact production `src/interpreter/translate.py::Translator.translate` implementation for the baseline, including the application's GPU bootstrap and output normalization. It clears the fuzzy translation cache before every measured call so every score and timing measures the model rather than a previous corpus entry.
+
+## Frozen corpus
+
+`sources.json` defines 268 aligned semantic pairs from eight real 8-bit/16-bit games and four independent fan-translation projects. `corpus.py prepare` downloads the exact files at full Git commit URLs, verifies raw-byte SHA-256 hashes, removes non-visible control/layout codes, excludes dynamic placeholders and debug metadata, and samples each game/type/length stratum by a fixed SHA-256 rank. It does all of this before a model runs.
+
+| Platform | Games | Pairs |
+|---|---|---:|
+| Famicom Disk System | Famicom Detective Club: The Girl Who Stands Behind; The Missing Heir; Shin Onigashima; Time Twist; Yūyūki | 150 |
+| NEC PC-9801 | Dragon Slayer: The Legend of Heroes | 50 |
+| Sega Master System | Phantasy Star | 33 |
+| Super Famicom | Metal Slader Glory: Director's Cut | 35 |
+
+The selected set contains 188 dialogue, 70 menu, and 10 system pairs: 121 short, 78 medium, and 69 long. Every pair has a `screen` track. When the source project also supplies a kanji-normalized transcription, the same reference is expanded into a `normalized` diagnostic track. There are 268 screen samples and 136 distinct normalized samples, for 404 model calls per repeat. The screen track—not normalized prose—is the promotion metric.
+
+The source projects are pinned to:
+
+- [sudgy/nintendo_translations at `39f7fb4`](https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2), which supplies exact display text, normalized Japanese, and English for five FDS games.
+- [maxim-zhao/psrp at `2a327b7`](https://github.com/maxim-zhao/psrp/tree/2a327b7163eb7864c004ac2f46a00e66a88d2e1d), which supplies display/normalized Japanese plus literal and official-localization alternatives for Phantasy Star.
+- [romh-acking/metal-slader-glory-sfc-en at `beb3e86`](https://github.com/romh-acking/metal-slader-glory-sfc-en/tree/beb3e86dec0fd928ac165eaa7b9bfe29358b03ea), which supplies aligned SFC script text and a fan translation.
+- [nleseul/ds6_pc98_trans at `2d32f8f`](https://github.com/nleseul/ds6_pc98_trans/tree/2d32f8f93afa50dbe8003521624194a91a6f86a9), which supplies aligned PC-98 dialogue, menu, and battle text for Dragon Slayer: The Legend of Heroes.
+
+These are public corpora, so unknown training contamination remains possible. Most references have only one source, and the Nintendo repository itself describes its translations as nonprofessional. Automatic results are therefore evidence for ranking and regression detection, not sufficient evidence to ship a model. The promotion gate requires at least 100 independently verified, model-blind human references across five games, a separate private holdout, and a blind human A/B result. `reviews.json` deliberately starts empty; AI review does not count as independent verification.
+
+No synthetic text or generated screenshots are accepted. Downloaded source files, generated locks, model caches, raw results, and review packets live under ignored directories. Only the compact registries and tooling are committed.
+
+## Models
+
+`models.json` pins every repository to a full Hugging Face revision and pins its benchmark packages. The default overnight matrix is:
+
+| ID | Model | Parameters/artifacts | Inference profile |
+|---|---|---|---|
+| `production` | [Sugoi V4 CTranslate2](https://huggingface.co/entai2965/sugoi-v4-ja-en-ctranslate2) | about 1.1 GB | Exact application path, beam 5 |
+| `quickmt` | [QuickMT ja-en](https://huggingface.co/quickmt/quickmt-ja-en) | 200M/about 0.4 GB CT2 subset | Repository SentencePiece models, beam 5 |
+| `lfm2-350m` | [LFM2-350M-ENJP-MT](https://huggingface.co/LiquidAI/LFM2-350M-ENJP-MT) | 350M/about 0.7 GB | Required `Translate to English.` system turn and documented sampling profile, deterministically seeded per source |
+| `hy-mt-1.8b` | [HY-MT1.5-1.8B](https://huggingface.co/tencent/HY-MT1.5-1.8B) | 1.8B/about 4.1 GB | Documented no-explanation prompt and sampling profile, deterministically seeded per source |
+| `riva-4b-v2` | [Riva-Translate-4B-Instruct-v2](https://huggingface.co/nvidia/Riva-Translate-4B-Instruct-v2) | 4B/about 8.4 GB | Required `ja-en` system turn, greedy decoding |
+
+[TranslateGemma 4B](https://huggingface.co/google/translategemma-4b-it) is also registered and supported, but is excluded from the default matrix because its Gemma license must first be accepted on Hugging Face. Pass it explicitly after setting `HF_TOKEN`.
+
+The transformer environments use the pinned CUDA 12.8 PyTorch index. QuickMT includes the same pip CUDA runtime packages the application uses for CTranslate2. Each candidate runs in a separate `uv --isolated --no-project` environment and a separate ignored Hugging Face cache, so the benchmark never edits the application environment or lock file. The report records the resolved revision, SHA-256 of every loaded artifact, package versions, actual device/dtype, peak PyTorch GPU allocation, application source hashes, and Git state.
+
+Model licenses differ and are not interchangeable with the repository's MIT license. The comparison gate stays closed until the intended deployment license has been reviewed; a good metric does not grant redistribution rights.
+
+## Run it
+
+From the repository root on Windows:
+
+```powershell
+$env:PYTHONUTF8 = "1"
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py prepare
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py inventory
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py validate
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py matrix
+```
+
+On macOS/Linux, replace `.\.venv\Scripts\python.exe` with `.venv/bin/python`.
+
+The default matrix runs production plus all four accessible candidates, three timed repeats, two warm-ups, chrF++/BLEU, pinned WMT22 COMET, and a paired comparison for each candidate. It can download roughly 17 GB of model and metric artifacts. Raw and scored JSON reports go to ignored `benchmark/translation/results/`.
+
+Useful smaller commands:
+
+```powershell
+# One deterministic smoke sample; no metric package required
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py run `
+  --model-id production --limit 1 --repeats 1 --warmups 0 `
+  --output benchmark\translation\results\production-smoke.json
+
+# Run only lightweight candidates and skip COMET
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py matrix `
+  --candidate quickmt --candidate lfm2-350m --skip-comet
+
+# Run the gated candidate after accepting its terms
+$env:HF_TOKEN = "..."
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py matrix `
+  --candidate translategemma-4b
+```
+
+Scoring is intentionally outside project dependencies:
+
+```powershell
+uv run --isolated --no-project --with sacrebleu==2.5.1 python `
+  benchmark\translation\benchmark.py score result.json
+
+uv run --isolated --no-project --with sacrebleu==2.5.1 python `
+  benchmark\translation\benchmark.py compare baseline-scored.json candidate-scored.json
+```
+
+`compare` fails closed unless both reports have the same frozen corpus fingerprint, source/review/model registries, production translation and worker source hashes, benchmark runner files, workload settings, ordered IDs, exact sources, and references. Changing an ID while retaining different text is not enough to make reports comparable.
+
+## Metrics and decision rule
+
+The primary automatic statistic is the paired difference in per-sample chrF++ on the 268 screen-track pairs. Multiple legitimate references are scored together. A deterministic 10,000-resample paired bootstrap supplies a 95% confidence interval. First-reference corpus chrF++ and BLEU are secondary surface-form metrics; reference-based WMT22 COMET is an optional semantic cross-check. Reports also include:
+
+- results by game, platform, dialogue/menu, source length, and normalized/screen track;
+- model load time and per-call median/p95 latency;
+- empty output, inference error, Japanese leakage, numeric-token preservation, and repeated-output determinism;
+- model artifact footprint and, for PyTorch CUDA models, peak allocated VRAM.
+
+A candidate is not promotion-ready unless the lower paired chrF++ confidence bound is above zero, no game regresses beyond the configured tolerance, reliability diagnostics pass, interactive latency and artifact budgets pass, and all reference/human/private/license gates pass. The limits are command options, but lowering them after seeing a candidate's output invalidates the decision.
+
+chrF++ and BLEU remain imperfect for creative game localization. Speaker voice, gender, names, jokes, implied subjects, and terse menu context need bilingual review. COMET is learned and may share web-data biases. Treat agreement between metrics as stronger evidence, not a substitute for blind human judgments.
+
+## Blind review
+
+Create a randomized A/B sheet and a separate decoder key:
+
+```powershell
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py blind-packet `
+  production-scored.json candidate-scored.json `
+  --packet benchmark\translation\results\human-ab.csv `
+  --key benchmark\translation\results\human-ab-key.json
+```
+
+Give reviewers only the CSV. They enter `A`, `B`, `TIE`, or `INVALID`; they should not see the key, model names, automatic scores, or source-project English. After collection:
+
+```powershell
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py blind-score `
+  benchmark\translation\results\human-ab.csv `
+  benchmark\translation\results\human-ab-key.json `
+  --output benchmark\translation\results\human-ab-scored.json
+```
+
+The scorer verifies that source text and either translation were not edited after randomization and reports a Wilson 95% interval for decisive preferences. Pass that JSON to `compare --blind-review ...`. Reference verification is a different task and must be blind to all model outputs; create its sheet before results are shown with `reference-packet`.
+
+## Production fuzzy-cache diagnostic
+
+Model quality calls are uncached, but the application uses a 0.90 `SequenceMatcher` fuzzy cache in normal operation. Audit the frozen player-visible texts independently with:
+
+```powershell
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py cache-audit `
+  --output benchmark\translation\results\cache-audit.json
+```
+
+This is a static worst-case collision check, not part of candidate scoring, because runtime behavior also depends on which recent screenshots are still in the cache.
+
+## Tests
+
+```powershell
+.\.venv\Scripts\ruff.exe check benchmark\translation tests\test_translation_benchmark.py
+.\.venv\Scripts\pytest.exe tests\test_translation_benchmark.py
+```

--- a/benchmark/translation/RESULTS.md
+++ b/benchmark/translation/RESULTS.md
@@ -1,0 +1,76 @@
+# Translation benchmark results — 2026-08-31
+
+**Decision: keep the production Sugoi V4 model.** None of the four accessible candidates proved better on the primary player-visible-text metric, and none passed the predeclared deployment and evidence gates. No production model or setting was changed.
+
+## Run identity
+
+- Benchmark commit: `d33bae53656f04cbe0dcebecdfacba477026e14c`
+- Corpus fingerprint: `8b03090234f41ce82ee737030dd0590674bb005acc1dc74b650ef9aa810b8d31`
+- Workload: 268 independent `screen` pairs plus 136 `normalized` diagnostics; two warm-ups and three timed calls per model/sample
+- Hardware: NVIDIA GeForce RTX 4070 Ti, Windows 11, Python 3.12.12; every model and COMET ran on CUDA
+- Metrics: SacreBLEU 2.5.1 chrF++/BLEU and pinned `Unbabel/wmt22-comet-da` revision `2760a223ac957f30acfb18c8aa649b01cf1d75f2`
+- Statistical test: paired 10,000-resample bootstrap over the 268 screen pairs, seed 1729
+
+The command was:
+
+```powershell
+.\.venv\Scripts\python.exe benchmark\translation\benchmark.py matrix
+```
+
+Raw predictions and metric reports remain ignored because they are reproducible run artifacts. This file is the committed run summary.
+
+## Primary screen-track result
+
+Higher chrF++ and COMET are better. Deltas and confidence intervals are paired against production. Latency is synchronized end-to-end inference; artifact size excludes shared runtime packages.
+
+| Model | chrF++ | Paired chrF++ delta (95% CI) | COMET | Paired COMET delta (95% CI) | Median / p95 | Artifact | Outcome |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Production Sugoi V4 | 25.63 | — | 0.6068 | — | 41.8 / 244.0 ms | 1.03 GiB | Baseline |
+| QuickMT 200M | 22.59 | −3.04 [−5.35, −0.73] | 0.5759 | −0.0309 [−0.0452, −0.0168] | 21.7 / 97.7 ms | 0.38 GiB | **Worse** |
+| LFM2 350M | 23.33 | −2.30 [−4.62, +0.00] | 0.5946 | −0.0123 [−0.0278, +0.0033] | 307.7 / 1,426.1 ms | 0.66 GiB | Inconclusive |
+| HY-MT 1.8B | 27.38 | +1.75 [−0.90, +4.44] | 0.6489 | +0.0421 [+0.0228, +0.0609] | 813.2 / 4,000.7 ms | 3.81 GiB | Inconclusive |
+| Riva Translate 4B v2 | 25.79 | +0.15 [−2.11, +2.33] | 0.6361 | +0.0293 [+0.0136, +0.0451] | 537.3 / 3,005.4 ms | 7.80 GiB | Inconclusive |
+
+HY-MT and Riva score significantly higher under COMET, but not under the declared primary chrF++ test. That disagreement is useful evidence for a later blind bilingual review, not grounds to select the favorable metric after seeing results. QuickMT is 2.5× faster and much smaller than production, but is significantly worse on both quality metrics.
+
+## Coverage and regressions
+
+Mean screen chrF++ delta by game shows why a corpus-wide point estimate is insufficient:
+
+| Game | QuickMT | LFM2 | HY-MT | Riva |
+|---|---:|---:|---:|---:|
+| Dragon Slayer: The Legend of Heroes | −2.09 | −4.58 | −1.67 | −3.67 |
+| Famicom Detective Club: The Girl Who Stands Behind | −5.78 | −3.76 | +5.95 | −1.86 |
+| Famicom Detective Club: The Missing Heir | −8.59 | −5.81 | −2.83 | −0.56 |
+| Shin Onigashima | +0.89 | +1.32 | +4.70 | +1.28 |
+| Yūyūki | +2.05 | +3.30 | +10.12 | +9.18 |
+| Metal Slader Glory: Director's Cut | −4.50 | −4.25 | −4.98 | −2.01 |
+| Phantasy Star | −1.62 | −3.11 | +0.76 | −0.28 |
+| Time Twist | −5.21 | +0.41 | +5.45 | +2.11 |
+
+HY-MT therefore trips the greater-than-2 chrF++ regression guard on The Missing Heir and Metal Slader Glory despite having the best overall point estimate. Riva trips it on Dragon Slayer and Metal Slader Glory.
+
+The normalized diagnostic confirms why the screen track must remain primary:
+
+| Model | Normalized chrF++ | Normalized COMET |
+|---|---:|---:|
+| Production | 42.86 | 0.7808 |
+| QuickMT | 38.75 | 0.7454 |
+| LFM2 | 38.85 | 0.7638 |
+| HY-MT | 42.88 | 0.7920 |
+| Riva | 44.61 | 0.8030 |
+
+Every model scores much better on normalized Japanese than on the kana-heavy text players and OCR actually provide. Ranking only normalized prose would materially overstate real-game quality.
+
+## Reliability and promotion gates
+
+Each of the five models completed 1,212 measured calls with zero inference errors, zero empty outputs, and zero nondeterministic samples. Production, QuickMT, and Riva had no Japanese-script leakage; LFM2 and HY-MT each left one source fragment untranslated. Numeric-token preservation was 15/19 for production, versus 10/19 QuickMT, 11/19 LFM2, 13/19 HY-MT, and 12/19 Riva. The numeric slice is small and should be expanded, but every candidate failed the predeclared no-regression check.
+
+No candidate is promotion-ready. In addition to the automatic quality/latency/size blockers above, the deliberately fail-closed evidence gates still report:
+
+- 0 independently verified references (100 required) across 0 verified games (5 required);
+- 0 blind human A/B judgments (100 required);
+- no separate private holdout result; and
+- no completed deployment-license review.
+
+The public corpora may overlap model training data, most references come from one nonprofessional fan translation, and valid localization alternatives can receive low surface-form scores. TranslateGemma 4B was not run because its gated Gemma terms have not been accepted for this environment. The next defensible evaluation step is independent bilingual reference review followed by a private holdout and blind production-vs-HY/Riva A/B test—not a model replacement.

--- a/benchmark/translation/adapters.py
+++ b/benchmark/translation/adapters.py
@@ -1,0 +1,573 @@
+"""Pinned translation-model adapters used by the benchmark runner."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import os
+import platform
+import random
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+from benchlib import BenchmarkError, fingerprint, sha256_file
+
+_GPU_LIBRARY_HANDLES: list[Any] = []
+
+
+class _SilentLogger:
+    def __getattr__(self, _name: str):
+        return lambda *args, **kwargs: None
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise BenchmarkError(f"Could not load application module {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_application_translator(repo_root: Path):
+    """Load production translate.py without importing the GUI or capture stack."""
+
+    source_root = repo_root / "src" / "interpreter"
+    translate_path = source_root / "translate.py"
+    if not translate_path.is_file():
+        raise BenchmarkError(f"Interpreter translation source not found under {repo_root}")
+
+    package = types.ModuleType("interpreter")
+    package.__path__ = [str(source_root)]
+    sys.modules["interpreter"] = package
+
+    log_module = types.ModuleType("interpreter.log")
+    log_module.get_logger = lambda *_args, **_kwargs: _SilentLogger()
+    sys.modules["interpreter.log"] = log_module
+
+    models_module = types.ModuleType("interpreter.models")
+
+    class ModelLoadError(Exception):
+        pass
+
+    models_module.ModelLoadError = ModelLoadError
+    sys.modules["interpreter.models"] = models_module
+    return _load_module("interpreter.translate", translate_path).Translator
+
+
+def setup_application_gpu(repo_root: Path) -> bool:
+    """Run the same platform GPU bootstrap that the GUI performs at startup."""
+
+    platform_module = {"Windows": "windows", "Linux": "linux", "Darwin": "macos"}.get(platform.system())
+    if platform_module is None:
+        return False
+    path = repo_root / "src" / "interpreter" / "gpu" / f"{platform_module}.py"
+    module = _load_module(f"interpreter.gpu.{platform_module}", path)
+    return bool(module.setup())
+
+
+def setup_isolated_gpu_packages() -> list[str]:
+    """Register CUDA pip-package libraries across uv's overlay paths.
+
+    The application virtual environment keeps dependencies in one
+    site-packages directory. ``uv run --isolated --with`` may expose several
+    overlay directories, so the application's first-directory scan cannot see
+    every NVIDIA package. Candidate environments need this equivalent fallback
+    to exercise the device they would use when installed in the application.
+    """
+
+    system = platform.system()
+    subdirectory = "bin" if system == "Windows" else "lib" if system == "Linux" else None
+    if subdirectory is None:
+        return []
+    directories = sorted(
+        {
+            str(candidate.resolve())
+            for entry in sys.path
+            for package_root in [Path(entry) / "nvidia"]
+            if package_root.is_dir()
+            for package in package_root.iterdir()
+            if package.is_dir()
+            for candidate in [package / subdirectory]
+            if candidate.is_dir()
+        }
+    )
+    if not directories:
+        return []
+
+    variable = "PATH" if system == "Windows" else "LD_LIBRARY_PATH"
+    current = os.environ.get(variable, "")
+    existing = {value.casefold() for value in current.split(os.pathsep) if value}
+    additions = [value for value in directories if value.casefold() not in existing]
+    if additions:
+        os.environ[variable] = os.pathsep.join([*additions, current])
+
+    if system == "Windows":
+        for directory in directories:
+            try:
+                _GPU_LIBRARY_HANDLES.append(os.add_dll_directory(directory))
+            except (OSError, AttributeError):
+                pass
+    else:
+        import ctypes
+
+        for name in ("libcublas.so.12", "libcublasLt.so.12", "libcudnn.so.9"):
+            for directory in directories:
+                candidate = Path(directory) / name
+                if not candidate.is_file():
+                    continue
+                try:
+                    _GPU_LIBRARY_HANDLES.append(ctypes.CDLL(str(candidate), mode=ctypes.RTLD_GLOBAL))
+                except OSError:
+                    pass
+                break
+    return directories
+
+
+def normalize_display_output(text: str) -> str:
+    """Apply the output normalization currently embedded in Translator.translate."""
+
+    return (
+        text.strip()
+        .replace("\u2018", "'")
+        .replace("\u2019", "'")
+        .replace("\u201c", '"')
+        .replace("\u201d", '"')
+        .replace("\u2013", "-")
+        .replace("\u2014", "--")
+        .replace("\u2212", "-")
+        .replace("\u00a0", " ")
+        .replace("\u2026", "...")
+    )
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _snapshot_revision(path: Path) -> str | None:
+    parts = path.resolve().parts
+    try:
+        return parts[parts.index("snapshots") + 1]
+    except (ValueError, IndexError):
+        return None
+
+
+def _snapshot_metadata(path: Path) -> dict[str, Any]:
+    files = []
+    for file_path in sorted(item for item in path.rglob("*") if item.is_file()):
+        relative = file_path.relative_to(path).as_posix()
+        files.append(
+            {
+                "path": relative,
+                "bytes": file_path.stat().st_size,
+                "sha256": sha256_file(file_path),
+            }
+        )
+    return {
+        "resolved_revision": _snapshot_revision(path),
+        "bytes": sum(item["bytes"] for item in files),
+        "fingerprint": fingerprint(files),
+        "files": files,
+    }
+
+
+def _verify_revision(path: Path, model: dict[str, Any]) -> None:
+    expected = model.get("revision")
+    actual = _snapshot_revision(path)
+    if expected and actual != expected:
+        raise BenchmarkError(
+            f"Loaded {model['repo_id']} revision {actual or 'unknown'}, but models.json pins {expected}"
+        )
+
+
+def _download_snapshot(model: dict[str, Any], *, allow_patterns: list[str] | None = None) -> Path:
+    try:
+        from huggingface_hub import snapshot_download
+        from huggingface_hub.errors import GatedRepoError
+    except ImportError as exc:
+        raise BenchmarkError("The model environment must provide huggingface-hub") from exc
+
+    try:
+        path = Path(
+            snapshot_download(
+                repo_id=model["repo_id"],
+                revision=model["revision"],
+                allow_patterns=allow_patterns,
+            )
+        )
+    except GatedRepoError as exc:
+        raise BenchmarkError(
+            f"{model['repo_id']} is gated. Accept its license on Hugging Face and set HF_TOKEN before retrying."
+        ) from exc
+    _verify_revision(path, model)
+    return path
+
+
+class BaseAdapter:
+    """Small common interface; each adapter represents a deployable inference profile."""
+
+    prompt_contract = "plain Japanese source text"
+
+    def __init__(
+        self,
+        model_id: str,
+        model: dict[str, Any],
+        repo_root: Path,
+        device: str = "auto",
+        generation_seed: int = 1729,
+    ):
+        self.model_id = model_id
+        self.model = model
+        self.repo_root = repo_root
+        self.device_preference = device
+        self.generation_seed = generation_seed
+        self.device = "unknown"
+        self.compute_type: str | None = None
+        self.model_path: Path | None = None
+        self.runtime_setup: dict[str, Any] = {}
+
+    def load(self) -> None:
+        raise NotImplementedError
+
+    def translate(self, text: str) -> str:
+        raise NotImplementedError
+
+    def clear_cache(self) -> None:
+        """Clear application-level memoization before a measured translation."""
+
+    def synchronize(self) -> None:
+        """Wait for asynchronous device work before stopping a timer."""
+
+    def metadata(self) -> dict[str, Any]:
+        if self.model_path is None:
+            raise BenchmarkError("Adapter metadata requested before the model was loaded")
+        return {
+            "id": self.model_id,
+            "registry": self.model,
+            "repo_id": self.model["repo_id"],
+            "adapter": self.model["adapter"],
+            "device_preference": self.device_preference,
+            "device": self.device,
+            "compute_type": self.compute_type,
+            "prompt_contract": self.prompt_contract,
+            "generation": self.model["generation"],
+            "generation_seed": self.generation_seed,
+            "runtime_setup": self.runtime_setup,
+            "artifacts": _snapshot_metadata(self.model_path),
+        }
+
+
+class ProductionAdapter(BaseAdapter):
+    prompt_contract = "exact src/interpreter/translate.py::Translator.translate path; cache cleared per call"
+
+    def load(self) -> None:
+        if self.device_preference != "auto":
+            raise BenchmarkError("The production adapter uses Translator.load's exact automatic device selection")
+        self.runtime_setup["application_gpu_setup"] = setup_application_gpu(self.repo_root)
+        Translator = load_application_translator(self.repo_root)
+        self.translator = Translator()
+        self.translator.load()
+        self.model_path = Path(self.translator._model_path)
+        _verify_revision(self.model_path, self.model)
+        engine = self.translator._translator
+        self.device = str(getattr(engine, "device", "unknown"))
+        self.compute_type = str(getattr(engine, "compute_type", "unknown"))
+
+    def clear_cache(self) -> None:
+        self.translator._cache._cache.clear()
+
+    def translate(self, text: str) -> str:
+        prediction, was_cached = self.translator.translate(text)
+        if was_cached:
+            raise BenchmarkError("Production translation unexpectedly used its fuzzy cache during a measured call")
+        return prediction
+
+
+class QuickMTAdapter(BaseAdapter):
+    prompt_contract = "plain source passed through the repository's source SentencePiece model"
+
+    def load(self) -> None:
+        self.runtime_setup["application_gpu_setup"] = setup_application_gpu(self.repo_root)
+        self.runtime_setup["isolated_gpu_package_directories"] = setup_isolated_gpu_packages()
+        try:
+            import ctranslate2
+            import sentencepiece as sentencepiece
+        except ImportError as exc:
+            raise BenchmarkError("QuickMT requires ctranslate2 and sentencepiece") from exc
+
+        self.model_path = _download_snapshot(
+            self.model,
+            allow_patterns=[
+                "config.json",
+                "model.bin",
+                "source_vocabulary.json",
+                "target_vocabulary.json",
+                "src.spm.model",
+                "tgt.spm.model",
+            ],
+        )
+        requested = self.device_preference
+        if requested not in {"auto", "cuda", "cpu"}:
+            raise BenchmarkError(f"Invalid device: {requested}")
+        attempts = [requested] if requested != "auto" else ["cuda", "cpu"]
+        last_error: Exception | None = None
+        for device in attempts:
+            try:
+                translator = ctranslate2.Translator(str(self.model_path), device=device)
+                translator.translate_batch([["テスト"]], beam_size=1, max_decoding_length=8)
+                self.translator = translator
+                self.device = device
+                self.compute_type = str(getattr(translator, "compute_type", "unknown"))
+                break
+            except Exception as exc:  # CUDA availability is ultimately verified by inference.
+                last_error = exc
+        else:
+            raise BenchmarkError(f"Could not load QuickMT on {attempts}: {last_error}") from last_error
+
+        self.source_tokenizer = sentencepiece.SentencePieceProcessor(
+            model_proto=(self.model_path / "src.spm.model").read_bytes()
+        )
+        self.target_tokenizer = sentencepiece.SentencePieceProcessor(
+            model_proto=(self.model_path / "tgt.spm.model").read_bytes()
+        )
+
+    def translate(self, text: str) -> str:
+        tokens = self.source_tokenizer.EncodeAsPieces(text)
+        result = self.translator.translate_batch(
+            [tokens],
+            beam_size=self.model["generation"]["beam_size"],
+            max_decoding_length=self.model["generation"]["max_decoding_length"],
+        )[0]
+        prediction = self.target_tokenizer.DecodePieces(result.hypotheses[0])
+        return normalize_display_output(prediction)
+
+
+class TransformersAdapter(BaseAdapter):
+    add_generation_prompt = True
+
+    def tokenizer_kwargs(self) -> dict[str, Any]:
+        return {}
+
+    def load(self) -> None:
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+        except ImportError as exc:
+            raise BenchmarkError("This adapter requires torch and transformers") from exc
+
+        self.torch = torch
+        self.model_path = _download_snapshot(self.model)
+        requested = self.device_preference
+        if requested not in {"auto", "cuda", "cpu"}:
+            raise BenchmarkError(f"Invalid device: {requested}")
+        if requested == "cuda" and not torch.cuda.is_available():
+            raise BenchmarkError("CUDA was requested but torch.cuda.is_available() is false")
+        self.device = "cuda" if requested == "cuda" or (requested == "auto" and torch.cuda.is_available()) else "cpu"
+        dtype = torch.bfloat16 if self.device == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+        self.compute_type = str(dtype).removeprefix("torch.")
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            str(self.model_path),
+            local_files_only=True,
+            **self.tokenizer_kwargs(),
+        )
+        self.transformer = AutoModelForCausalLM.from_pretrained(
+            str(self.model_path),
+            local_files_only=True,
+            dtype=dtype,
+            low_cpu_mem_usage=True,
+        )
+        self.transformer.to(self.device)
+        self.transformer.eval()
+        if self.device == "cuda":
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+
+    def messages(self, text: str) -> list[dict[str, str]]:
+        raise NotImplementedError
+
+    def _generation(self) -> dict[str, Any]:
+        return dict(self.model["generation"])
+
+    def synchronize(self) -> None:
+        if self.device == "cuda":
+            self.torch.cuda.synchronize()
+
+    def translate(self, text: str) -> str:
+        torch = self.torch
+        # Sampling profiles are made repeatable per source so latency repeats do
+        # not silently become multiple quality trials.
+        seed = int(
+            fingerprint({"model": self.model_id, "source": text, "seed": self.generation_seed})[:8],
+            16,
+        )
+        random.seed(seed)
+        torch.manual_seed(seed)
+        if self.device == "cuda":
+            torch.cuda.manual_seed_all(seed)
+
+        input_ids = self.tokenizer.apply_chat_template(
+            self.messages(text),
+            tokenize=True,
+            add_generation_prompt=self.add_generation_prompt,
+            return_tensors="pt",
+        ).to(self.device)
+        generation = self._generation()
+        generation.setdefault("pad_token_id", self.tokenizer.eos_token_id)
+        with torch.inference_mode():
+            outputs = self.transformer.generate(
+                input_ids,
+                attention_mask=torch.ones_like(input_ids),
+                **generation,
+            )
+        generated = outputs[0, input_ids.shape[-1] :]
+        return normalize_display_output(self.tokenizer.decode(generated, skip_special_tokens=True))
+
+    def metadata(self) -> dict[str, Any]:
+        value = super().metadata()
+        value["tokenizer_options"] = self.tokenizer_kwargs()
+        if self.device == "cuda":
+            value["peak_cuda_memory_bytes"] = self.torch.cuda.max_memory_allocated()
+            value["cuda_device"] = self.torch.cuda.get_device_name()
+        return value
+
+
+class LFM2Adapter(TransformersAdapter):
+    prompt_contract = 'system "Translate to English." plus one user turn; repository chat template'
+
+    def messages(self, text: str) -> list[dict[str, str]]:
+        return [
+            {"role": "system", "content": "Translate to English."},
+            {"role": "user", "content": text},
+        ]
+
+
+class HYMTAdapter(TransformersAdapter):
+    prompt_contract = (
+        'single user turn: "Translate the following segment into English, without additional explanation."'
+    )
+    add_generation_prompt = False
+
+    def messages(self, text: str) -> list[dict[str, str]]:
+        return [
+            {
+                "role": "user",
+                "content": "Translate the following segment into English, without additional explanation.\n\n" + text,
+            }
+        ]
+
+
+class RivaAdapter(TransformersAdapter):
+    prompt_contract = 'system language pair "ja-en" plus one user turn; repository chat template'
+
+    def messages(self, text: str) -> list[dict[str, str]]:
+        return [{"role": "system", "content": "ja-en"}, {"role": "user", "content": text}]
+
+    def tokenizer_kwargs(self) -> dict[str, Any]:
+        # Transformers detects the legacy Mistral tokenizer regex in this
+        # checkpoint and explicitly recommends enabling its compatibility fix.
+        return {"fix_mistral_regex": True}
+
+
+class TranslateGemmaAdapter(TransformersAdapter):
+    prompt_contract = "TranslateGemma typed text turn with source_lang_code=ja and target_lang_code=en"
+
+    def load(self) -> None:
+        try:
+            import torch
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+        except ImportError as exc:
+            raise BenchmarkError("TranslateGemma requires a transformers release with Gemma 3 support") from exc
+
+        self.torch = torch
+        self.model_path = _download_snapshot(self.model)
+        requested = self.device_preference
+        if requested not in {"auto", "cuda", "cpu"}:
+            raise BenchmarkError(f"Invalid device: {requested}")
+        if requested == "cuda" and not torch.cuda.is_available():
+            raise BenchmarkError("CUDA was requested but torch.cuda.is_available() is false")
+        self.device = "cuda" if requested == "cuda" or (requested == "auto" and torch.cuda.is_available()) else "cpu"
+        dtype = torch.bfloat16 if self.device == "cuda" and torch.cuda.is_bf16_supported() else torch.float32
+        self.compute_type = str(dtype).removeprefix("torch.")
+        self.processor = AutoProcessor.from_pretrained(str(self.model_path), local_files_only=True)
+        self.transformer = AutoModelForImageTextToText.from_pretrained(
+            str(self.model_path),
+            local_files_only=True,
+            dtype=dtype,
+            low_cpu_mem_usage=True,
+        ).to(self.device)
+        self.transformer.eval()
+        if self.device == "cuda":
+            torch.cuda.synchronize()
+            torch.cuda.reset_peak_memory_stats()
+
+    def translate(self, text: str) -> str:
+        torch = self.torch
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "source_lang_code": "ja",
+                        "target_lang_code": "en",
+                        "text": text,
+                    }
+                ],
+            }
+        ]
+        inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        ).to(self.device)
+        with torch.inference_mode():
+            outputs = self.transformer.generate(**inputs, **self.model["generation"])
+        generated = outputs[0, inputs["input_ids"].shape[-1] :]
+        return normalize_display_output(self.processor.decode(generated, skip_special_tokens=True))
+
+    def metadata(self) -> dict[str, Any]:
+        value = BaseAdapter.metadata(self)
+        if self.device == "cuda":
+            value["peak_cuda_memory_bytes"] = self.torch.cuda.max_memory_allocated()
+            value["cuda_device"] = self.torch.cuda.get_device_name()
+        return value
+
+
+ADAPTERS = {
+    "production": ProductionAdapter,
+    "quickmt": QuickMTAdapter,
+    "lfm2": LFM2Adapter,
+    "hy_mt": HYMTAdapter,
+    "riva": RivaAdapter,
+    "translategemma": TranslateGemmaAdapter,
+}
+
+
+def create_adapter(
+    model_id: str,
+    model: dict[str, Any],
+    repo_root: Path,
+    device: str = "auto",
+    generation_seed: int = 1729,
+) -> BaseAdapter:
+    adapter_name = model.get("adapter")
+    adapter_class = ADAPTERS.get(adapter_name)
+    if adapter_class is None:
+        raise BenchmarkError(f"Unknown model adapter: {adapter_name}")
+    return adapter_class(model_id, model, repo_root, device, generation_seed)
+
+
+def environment_package_versions(model: dict[str, Any]) -> dict[str, str | None]:
+    names = {requirement.split("==", 1)[0] for requirement in model.get("packages", [])}
+    names.update({"ctranslate2", "sentencepiece", "huggingface-hub", "torch", "transformers"})
+    return {name: _package_version(name) for name in sorted(names)}

--- a/benchmark/translation/benchlib.py
+++ b/benchmark/translation/benchlib.py
@@ -1,0 +1,462 @@
+"""Standard-library utilities for the Interpreter translation benchmark."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import re
+import statistics
+import unicodedata
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+DEFAULT_SOURCES = HERE / "sources.json"
+DEFAULT_MODELS = HERE / "models.json"
+DEFAULT_REVIEWS = HERE / "reviews.json"
+DEFAULT_DATA_DIR = HERE / "data"
+DEFAULT_RESULTS_DIR = HERE / "results"
+DEFAULT_LOCK = DEFAULT_DATA_DIR / "corpus.lock.json"
+
+TRACKS = {"screen", "normalized"}
+TEXT_TYPES = {"dialogue", "menu", "system"}
+LENGTH_BUCKETS = {"short", "medium", "long"}
+REFERENCE_STATUSES = {
+    "single_source_review",
+    "source_review_with_alternate",
+    "independently_verified",
+}
+
+_JAPANESE_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]")
+_NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:[.,]\d+)*(?![A-Za-z0-9])")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+class BenchmarkError(RuntimeError):
+    """A user-actionable benchmark failure."""
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BenchmarkError(f"Expected a JSON object in {path}")
+    return value
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def canonical_json(value: Any) -> bytes:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fingerprint(value: Any) -> str:
+    return sha256_bytes(canonical_json(value))
+
+
+def collapse_whitespace(text: str | None) -> str:
+    return _WHITESPACE_RE.sub(" ", (text or "").replace("\\", " ")).strip()
+
+
+def comparison_text(text: str | None) -> str:
+    return collapse_whitespace(unicodedata.normalize("NFKC", text or "")).casefold()
+
+
+def has_japanese(text: str | None) -> bool:
+    return bool(_JAPANESE_RE.search(text or ""))
+
+
+def japanese_character_count(text: str | None) -> int:
+    return len(_JAPANESE_RE.findall(text or ""))
+
+
+def source_character_count(text: str) -> int:
+    return sum(not character.isspace() for character in text)
+
+
+def length_bucket(text: str, limits: dict[str, list[int]]) -> str:
+    length = source_character_count(text)
+    for name in ("short", "medium", "long"):
+        lower, upper = limits[name]
+        if lower <= length <= upper:
+            return name
+    raise BenchmarkError(f"Source length {length} is outside the configured buckets")
+
+
+def stable_rank(seed: str, value: str) -> str:
+    return sha256_bytes(f"{seed}\0{value}".encode())
+
+
+def validate_source_registry(registry: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if registry.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if not isinstance(registry.get("corpus_id"), str) or not registry["corpus_id"]:
+        errors.append("corpus_id must be a non-empty string")
+    if not isinstance(registry.get("sampling_seed"), str) or not registry["sampling_seed"]:
+        errors.append("sampling_seed must be a non-empty string")
+    maximum = registry.get("maximum_source_characters")
+    if not isinstance(maximum, int) or maximum < 1:
+        errors.append("maximum_source_characters must be a positive integer")
+
+    buckets = registry.get("length_buckets")
+    if not isinstance(buckets, dict) or set(buckets) != LENGTH_BUCKETS:
+        errors.append(f"length_buckets must define exactly {sorted(LENGTH_BUCKETS)}")
+    else:
+        expected_lower = 1
+        for name in ("short", "medium", "long"):
+            bounds = buckets[name]
+            if (
+                not isinstance(bounds, list)
+                or len(bounds) != 2
+                or not all(isinstance(value, int) for value in bounds)
+                or bounds[0] != expected_lower
+                or bounds[1] < bounds[0]
+            ):
+                errors.append(f"length_buckets.{name} must be contiguous integer bounds")
+                break
+            expected_lower = bounds[1] + 1
+        if isinstance(maximum, int) and buckets.get("long", [None, None])[1] != maximum:
+            errors.append("long bucket upper bound must equal maximum_source_characters")
+
+    sources = registry.get("sources")
+    if not isinstance(sources, list) or not sources:
+        return [*errors, "sources must be a non-empty list"]
+
+    source_ids: set[str] = set()
+    for index, source in enumerate(sources):
+        prefix = f"sources[{index}]"
+        if not isinstance(source, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        source_id = source.get("id")
+        if not isinstance(source_id, str) or not source_id:
+            errors.append(f"{prefix}.id must be a non-empty string")
+        elif source_id in source_ids:
+            errors.append(f"duplicate source id: {source_id}")
+        else:
+            source_ids.add(source_id)
+        for field in ("game", "platform", "genre", "parser", "repository", "commit", "provenance_url", "license"):
+            if not isinstance(source.get(field), str) or not source[field]:
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+        if source.get("reference_status") not in REFERENCE_STATUSES:
+            errors.append(f"{prefix}.reference_status must be one of {sorted(REFERENCE_STATUSES)}")
+        if not isinstance(source.get("release_year"), int):
+            errors.append(f"{prefix}.release_year must be an integer")
+        if not str(source.get("repository", "")).startswith("https://github.com/"):
+            errors.append(f"{prefix}.repository must be an HTTPS GitHub URL")
+        if not re.fullmatch(r"[0-9a-f]{40}", str(source.get("commit", ""))):
+            errors.append(f"{prefix}.commit must be a full lowercase Git commit")
+
+        files = source.get("files")
+        required_role = "archive" if source.get("parser") == "ds6_pc98" else "messages"
+        if not isinstance(files, dict) or required_role not in files:
+            errors.append(f"{prefix}.files must contain {required_role}")
+        else:
+            for role, metadata in files.items():
+                file_prefix = f"{prefix}.files.{role}"
+                if not isinstance(metadata, dict):
+                    errors.append(f"{file_prefix} must be an object")
+                    continue
+                url = str(metadata.get("url", ""))
+                raw_url = url.startswith("https://raw.githubusercontent.com/")
+                archive_url = url == (
+                    f"https://codeload.github.com/{str(source.get('repository', '')).removeprefix('https://github.com/')}/"
+                    f"zip/{source.get('commit')}"
+                )
+                if not raw_url and not archive_url:
+                    errors.append(
+                        f"{file_prefix}.url must be a raw GitHub file or the source's exact-commit codeload ZIP"
+                    )
+                if not isinstance(metadata.get("path"), str) or not metadata["path"]:
+                    errors.append(f"{file_prefix}.path must be a non-empty string")
+                digest = metadata.get("sha256")
+                if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+                    errors.append(f"{file_prefix}.sha256 must be a lowercase SHA-256")
+
+        quotas = source.get("quotas")
+        if not isinstance(quotas, dict) or not quotas:
+            errors.append(f"{prefix}.quotas must be a non-empty object")
+        else:
+            for text_type, by_length in quotas.items():
+                if text_type not in TEXT_TYPES:
+                    errors.append(f"{prefix}.quotas has unknown text type {text_type}")
+                if not isinstance(by_length, dict) or set(by_length) != LENGTH_BUCKETS:
+                    errors.append(f"{prefix}.quotas.{text_type} must define exactly {sorted(LENGTH_BUCKETS)}")
+                elif not all(isinstance(value, int) and value >= 0 for value in by_length.values()):
+                    errors.append(f"{prefix}.quotas.{text_type} values must be non-negative integers")
+    return errors
+
+
+def validate_model_registry(registry: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if registry.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    models = registry.get("models")
+    if not isinstance(models, dict) or not models:
+        return [*errors, "models must be a non-empty object"]
+    for model_id, model in models.items():
+        prefix = f"models.{model_id}"
+        if not isinstance(model, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        for field in ("label", "adapter", "repo_id", "license", "deployment_status"):
+            if not isinstance(model.get(field), str) or not model[field]:
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+        revision = model.get("revision")
+        if revision is not None and not re.fullmatch(r"[0-9a-f]{40}", str(revision)):
+            errors.append(f"{prefix}.revision must be null or a full lowercase commit")
+        packages = model.get("packages")
+        if not isinstance(packages, list) or not all(isinstance(item, str) and item for item in packages):
+            errors.append(f"{prefix}.packages must be a string list")
+        indexes = model.get("uv_indexes", [])
+        if not isinstance(indexes, list) or not all(
+            isinstance(item, str) and item.startswith("https://") for item in indexes
+        ):
+            errors.append(f"{prefix}.uv_indexes must be an HTTPS URL list when provided")
+        if not isinstance(model.get("generation"), dict):
+            errors.append(f"{prefix}.generation must be an object")
+    return errors
+
+
+def validate_reviews(reviews: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if reviews.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    entries = reviews.get("reviews")
+    if not isinstance(entries, dict):
+        return [*errors, "reviews must be an object keyed by pair ID"]
+    for pair_id, review in entries.items():
+        if not isinstance(pair_id, str) or not pair_id:
+            errors.append("review pair IDs must be non-empty strings")
+        if not isinstance(review, dict):
+            errors.append(f"review {pair_id} must be an object")
+            continue
+        if review.get("status") not in {"verified", "rejected"}:
+            errors.append(f"review {pair_id}.status must be verified or rejected")
+        if review.get("reviewer_kind") != "human":
+            errors.append(f"review {pair_id}.reviewer_kind must be human")
+        if not isinstance(review.get("blind_to_model_outputs"), bool):
+            errors.append(f"review {pair_id}.blind_to_model_outputs must be boolean")
+    return errors
+
+
+def apply_reviews(entries: list[dict[str, Any]], reviews: dict[str, Any]) -> list[dict[str, Any]]:
+    by_id = reviews.get("reviews", {})
+    known_ids = {entry["pair_id"] for entry in entries}
+    unknown = sorted(set(by_id) - known_ids)
+    if unknown:
+        raise BenchmarkError(f"reviews.json refers to unknown pair IDs: {', '.join(unknown)}")
+
+    output = []
+    for entry in entries:
+        review = by_id.get(entry["pair_id"])
+        if review and review["status"] == "rejected":
+            continue
+        item = dict(entry)
+        item["independently_verified"] = bool(
+            review
+            and review["status"] == "verified"
+            and review["reviewer_kind"] == "human"
+            and review["blind_to_model_outputs"]
+        )
+        if item["independently_verified"]:
+            item["reference_status"] = "independently_verified"
+        output.append(item)
+    return output
+
+
+def select_entries(entries: list[dict[str, Any]], registry: dict[str, Any]) -> list[dict[str, Any]]:
+    """Select a frozen, stratified corpus without consulting model output."""
+
+    seed = registry["sampling_seed"]
+    sources = {source["id"]: source for source in registry["sources"]}
+    by_stratum: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    pair_ids: set[str] = set()
+    for entry in entries:
+        pair_id = entry.get("pair_id")
+        if not isinstance(pair_id, str) or not pair_id:
+            raise BenchmarkError("Parsed entry has no pair_id")
+        if pair_id in pair_ids:
+            raise BenchmarkError(f"Parser produced duplicate pair ID: {pair_id}")
+        pair_ids.add(pair_id)
+        source_id = entry.get("source_id")
+        if source_id not in sources:
+            raise BenchmarkError(f"Parsed entry has unknown source ID: {source_id}")
+        text_type = entry.get("text_type")
+        bucket = entry.get("length_bucket")
+        if text_type not in TEXT_TYPES or bucket not in LENGTH_BUCKETS:
+            raise BenchmarkError(f"Parsed entry {pair_id} has invalid strata")
+        by_stratum.setdefault((source_id, text_type, bucket), []).append(entry)
+
+    selected: list[dict[str, Any]] = []
+    for source in registry["sources"]:
+        source_id = source["id"]
+        for text_type, quotas in source["quotas"].items():
+            for bucket in ("short", "medium", "long"):
+                quota = quotas[bucket]
+                if not quota:
+                    continue
+                available = by_stratum.get((source_id, text_type, bucket), [])
+                if len(available) < quota:
+                    raise BenchmarkError(
+                        f"Corpus stratum {source_id}/{text_type}/{bucket} has {len(available)} entries; "
+                        f"the frozen quota requires {quota}"
+                    )
+                ranked = sorted(available, key=lambda item: (stable_rank(seed, item["pair_id"]), item["pair_id"]))
+                selected.extend(ranked[:quota])
+    return sorted(selected, key=lambda item: item["pair_id"])
+
+
+def expand_tracks(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    samples: list[dict[str, Any]] = []
+    for entry in entries:
+        common = {
+            key: entry[key]
+            for key in (
+                "pair_id",
+                "source_id",
+                "source_index",
+                "game",
+                "platform",
+                "release_year",
+                "genre",
+                "text_type",
+                "length_bucket",
+                "references",
+                "reference_status",
+                "independently_verified",
+                "provenance",
+            )
+        }
+        screen = {**common, "id": f"{entry['pair_id']}::screen", "track": "screen", "source": entry["screen"]}
+        samples.append(screen)
+        normalized = entry.get("normalized")
+        if normalized and comparison_text(normalized) != comparison_text(entry["screen"]):
+            samples.append(
+                {
+                    **common,
+                    "id": f"{entry['pair_id']}::normalized",
+                    "track": "normalized",
+                    "source": normalized,
+                }
+            )
+    return sorted(samples, key=lambda item: item["id"])
+
+
+def select_samples(
+    lock: dict[str, Any],
+    tracks: Iterable[str] | None = None,
+    games: Iterable[str] | None = None,
+    text_types: Iterable[str] | None = None,
+) -> list[dict[str, Any]]:
+    track_filter = set(tracks or [])
+    game_filter = set(games or [])
+    type_filter = set(text_types or [])
+    unknown_tracks = track_filter - TRACKS
+    if unknown_tracks:
+        raise BenchmarkError(f"Unknown track(s): {', '.join(sorted(unknown_tracks))}")
+    selected = []
+    for sample in lock.get("samples", []):
+        if track_filter and sample["track"] not in track_filter:
+            continue
+        if game_filter and sample["game"] not in game_filter:
+            continue
+        if type_filter and sample["text_type"] not in type_filter:
+            continue
+        selected.append(sample)
+    return selected
+
+
+def percentile(values: Iterable[float], quantile: float) -> float | None:
+    ordered = sorted(values)
+    if not ordered:
+        return None
+    if len(ordered) == 1:
+        return float(ordered[0])
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return float(ordered[lower])
+    weight = position - lower
+    return float(ordered[lower] * (1 - weight) + ordered[upper] * weight)
+
+
+def latency_summary(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    values = [value for sample in samples for value in sample.get("latencies_ms", [])]
+    return {
+        "measurements": len(values),
+        "median": statistics.median(values) if values else None,
+        "p95": percentile(values, 0.95),
+        "mean": statistics.fmean(values) if values else None,
+    }
+
+
+def number_tokens(text: str | None) -> Counter[str]:
+    normalized = unicodedata.normalize("NFKC", text or "")
+    return Counter(_NUMBER_RE.findall(normalized))
+
+
+def number_preservation(source: str, prediction: str) -> tuple[int, int]:
+    expected = number_tokens(source)
+    observed = number_tokens(prediction)
+    total = sum(expected.values())
+    preserved = sum(min(count, observed[token]) for token, count in expected.items())
+    return preserved, total
+
+
+def bootstrap_mean_delta(
+    baseline: dict[str, float],
+    candidate: dict[str, float],
+    iterations: int = 10_000,
+    seed: int = 1729,
+) -> dict[str, Any]:
+    ids = sorted(baseline.keys() & candidate.keys())
+    if not ids:
+        return {"pairs": 0, "delta": None, "ci95": [None, None], "iterations": 0, "seed": seed}
+    differences = [candidate[sample_id] - baseline[sample_id] for sample_id in ids]
+    observed = statistics.fmean(differences)
+    rng = random.Random(seed)
+    deltas = []
+    for _ in range(iterations):
+        deltas.append(statistics.fmean(differences[rng.randrange(len(differences))] for _ in differences))
+    return {
+        "pairs": len(ids),
+        "delta": observed,
+        "ci95": [percentile(deltas, 0.025), percentile(deltas, 0.975)],
+        "iterations": iterations,
+        "seed": seed,
+    }
+
+
+def modal_prediction(predictions: list[str]) -> str:
+    if not predictions:
+        return ""
+    counts = Counter(predictions)
+    maximum = max(counts.values())
+    return next(prediction for prediction in predictions if counts[prediction] == maximum)

--- a/benchmark/translation/benchlib.py
+++ b/benchmark/translation/benchlib.py
@@ -32,7 +32,9 @@ REFERENCE_STATUSES = {
     "independently_verified",
 }
 
-_JAPANESE_RE = re.compile(r"[\u3040-\u30ff\u3400-\u9fff]")
+# Script characters, intentionally excluding punctuation such as the katakana
+# middle dot (U+30FB). Punctuation-only output is not untranslated Japanese.
+_JAPANESE_RE = re.compile(r"[\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fd-\u30ff\u3400-\u9fff\uff66-\uff9d]")
 _NUMBER_RE = re.compile(r"(?<![A-Za-z0-9])\d+(?:[.,]\d+)*(?![A-Za-z0-9])")
 _WHITESPACE_RE = re.compile(r"\s+")
 

--- a/benchmark/translation/benchmark.py
+++ b/benchmark/translation/benchmark.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""CLI for the Interpreter Japanese-to-English translation benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from benchlib import (
+    DEFAULT_DATA_DIR,
+    DEFAULT_LOCK,
+    DEFAULT_MODELS,
+    DEFAULT_RESULTS_DIR,
+    DEFAULT_REVIEWS,
+    DEFAULT_SOURCES,
+    REPO_ROOT,
+    BenchmarkError,
+    comparison_text,
+    fingerprint,
+    load_json,
+    validate_model_registry,
+    validate_reviews,
+    validate_source_registry,
+    write_json,
+)
+from corpus import inventory, load_and_validate_lock, prepare_corpus
+from metrics import compare_results, format_scored_summary, score_results
+from review import create_blind_packet, create_reference_packet, score_blind_packet
+from runner import run_benchmark
+
+DEFAULT_CANDIDATES = ["quickmt", "lfm2-350m", "hy-mt-1.8b", "riva-4b-v2"]
+
+
+def _configure_console_utf8() -> None:
+    """Keep Japanese corpus output readable on legacy Windows consoles."""
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure:
+            reconfigure(encoding="utf-8", errors="replace")
+
+
+def _path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def _safe_slug(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-")[:80] or "model"
+
+
+def _add_registry_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--sources", type=_path, default=DEFAULT_SOURCES, help="Source/corpus registry JSON")
+    parser.add_argument("--reviews", type=_path, default=DEFAULT_REVIEWS, help="Independent reference reviews JSON")
+    parser.add_argument("--models", type=_path, default=DEFAULT_MODELS, help="Pinned model registry JSON")
+    parser.add_argument("--data-dir", type=_path, default=DEFAULT_DATA_DIR, help="Ignored downloaded corpus directory")
+    parser.add_argument("--lock", type=_path, default=DEFAULT_LOCK, help="Generated frozen corpus lock")
+
+
+def _add_workload_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--track", action="append", dest="tracks", choices=["screen", "normalized"])
+    parser.add_argument("--game", action="append", dest="games", help="Exact game title; repeat to select several")
+    parser.add_argument("--text-type", action="append", dest="text_types", choices=["dialogue", "menu", "system"])
+    parser.add_argument("--repeats", type=int, default=3, help="Timed translations per sample (default: 3)")
+    parser.add_argument("--warmups", type=int, default=2, help="Untimed warm-up calls (default: 2)")
+    parser.add_argument("--seed", type=int, default=1729, help="Deterministic order/generation seed")
+    parser.add_argument("--limit", type=int, help="Deterministic smoke-test limit; omit for the full corpus")
+    parser.add_argument("--device", choices=["auto", "cuda", "cpu"], default="auto")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inventory_parser = subparsers.add_parser("inventory", help="Show frozen corpus composition")
+    _add_registry_arguments(inventory_parser)
+
+    prepare = subparsers.add_parser("prepare", help="Download, hash-check, parse, and freeze the URL corpus")
+    _add_registry_arguments(prepare)
+
+    validate = subparsers.add_parser("validate", help="Validate registries, frozen records, and downloaded bytes")
+    _add_registry_arguments(validate)
+
+    run = subparsers.add_parser("run", help="Run one pinned model without requiring metric packages")
+    _add_registry_arguments(run)
+    _add_workload_arguments(run)
+    run.add_argument("--model-id", required=True)
+    run.add_argument("--label")
+    run.add_argument("--output", type=_path, required=True)
+
+    score = subparsers.add_parser("score", help="Add SacreBLEU chrF++/BLEU and optional COMET scores")
+    score.add_argument("results", nargs="+", type=_path)
+    score.add_argument("--output-dir", type=_path)
+    score.add_argument("--comet", action="store_true", help="Also run pinned WMT22 reference-based COMET")
+    score.add_argument("--comet-batch-size", type=int, default=16)
+
+    compare = subparsers.add_parser("compare", help="Fail-closed paired comparison of two result reports")
+    compare.add_argument("baseline", type=_path)
+    compare.add_argument("candidate", type=_path)
+    compare.add_argument("--output", type=_path)
+    compare.add_argument("--blind-review", type=_path, help="Scored model-blind human review JSON")
+    compare.add_argument("--bootstrap-iterations", type=int, default=10_000)
+    compare.add_argument("--bootstrap-seed", type=int, default=1729)
+    compare.add_argument("--min-verified-pairs", type=int, default=100)
+    compare.add_argument("--min-games", type=int, default=5)
+    compare.add_argument("--min-blind-judgments", type=int, default=100)
+    compare.add_argument("--max-p95-ms", type=float, default=750.0)
+    compare.add_argument("--max-latency-ratio", type=float, default=10.0)
+    compare.add_argument("--max-artifact-gib", type=float, default=5.0)
+    compare.add_argument("--max-artifact-ratio", type=float, default=4.0)
+    compare.add_argument("--max-game-regression", type=float, default=2.0)
+    compare.add_argument("--private-holdout-passed", action="store_true")
+    compare.add_argument("--license-approved", action="store_true")
+
+    matrix = subparsers.add_parser(
+        "matrix", help="Run production and accessible candidates in isolated, pinned environments"
+    )
+    _add_registry_arguments(matrix)
+    _add_workload_arguments(matrix)
+    matrix.add_argument("--candidate", action="append", dest="candidates", help="Model ID; repeat for several")
+    matrix.add_argument("--results-dir", type=_path, default=DEFAULT_RESULTS_DIR)
+    matrix.add_argument("--skip-comet", action="store_true", help="Skip the slower semantic COMET metric")
+    matrix.add_argument("--comet-batch-size", type=int, default=16)
+    matrix.add_argument("--bootstrap-iterations", type=int, default=10_000)
+
+    blind = subparsers.add_parser("blind-packet", help="Randomize a separate-key A/B human review CSV")
+    blind.add_argument("baseline", type=_path)
+    blind.add_argument("candidate", type=_path)
+    blind.add_argument("--packet", type=_path, required=True)
+    blind.add_argument("--key", type=_path, required=True)
+    blind.add_argument("--track", choices=["screen", "normalized"], default="screen")
+    blind.add_argument("--limit", type=int)
+    blind.add_argument("--seed", type=int, default=1729)
+
+    blind_score = subparsers.add_parser("blind-score", help="Decode a completed A/B CSV using its held key")
+    blind_score.add_argument("packet", type=_path)
+    blind_score.add_argument("key", type=_path)
+    blind_score.add_argument("--output", type=_path, required=True)
+
+    reference = subparsers.add_parser(
+        "reference-packet", help="Create a pre-output bilingual review sheet for corpus references"
+    )
+    _add_registry_arguments(reference)
+    reference.add_argument("--packet", type=_path, required=True)
+    reference.add_argument("--limit", type=int)
+    reference.add_argument("--seed", type=int, default=1729)
+
+    cache = subparsers.add_parser(
+        "cache-audit", help="Find context-free corpus texts that can collide in production's fuzzy cache"
+    )
+    _add_registry_arguments(cache)
+    cache.add_argument("--threshold", type=float, default=0.9)
+    cache.add_argument("--output", type=_path)
+    return parser
+
+
+def _load_registries(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    sources = load_json(args.sources)
+    reviews = load_json(args.reviews)
+    models = load_json(args.models)
+    errors = [
+        *validate_source_registry(sources),
+        *validate_reviews(reviews),
+        *validate_model_registry(models),
+    ]
+    if errors:
+        raise BenchmarkError("Benchmark registry validation failed:\n- " + "\n- ".join(errors))
+    return sources, reviews, models
+
+
+def _load_lock(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    sources, reviews, models = _load_registries(args)
+    lock = load_and_validate_lock(args.lock, args.data_dir, sources, reviews)
+    return lock, models, sources
+
+
+def _print_inventory(value: dict[str, Any]) -> None:
+    print(f"eligible pairs: {value['eligible_pairs']}")
+    print(f"selected pairs: {value['selected_pairs']}")
+    print(f"expanded samples: {value['samples']}")
+    print(f"independently verified pairs: {value['verified_pairs']}")
+    for field in ("games", "platforms", "text_types", "length_buckets", "tracks"):
+        print(f"{field}:")
+        for name, count in value[field].items():
+            print(f"  {name}: {count}")
+
+
+def _prepare(args: argparse.Namespace) -> dict[str, Any]:
+    sources, reviews, _ = _load_registries(args)
+    lock = prepare_corpus(sources, reviews, args.data_dir, args.sources, args.reviews)
+    if args.lock.resolve() != (args.data_dir / "corpus.lock.json").resolve():
+        write_json(args.lock, lock)
+    print(f"corpus fingerprint: {fingerprint(lock)}")
+    _print_inventory(inventory(lock))
+    return lock
+
+
+def _run(args: argparse.Namespace) -> dict[str, Any]:
+    lock, models, _ = _load_lock(args)
+    result = run_benchmark(
+        lock=lock,
+        lock_path=args.lock,
+        model_registry=models,
+        model_registry_path=args.models,
+        model_id=args.model_id,
+        repo_root=REPO_ROOT,
+        label=args.label,
+        tracks=args.tracks,
+        games=args.games,
+        text_types=args.text_types,
+        repeats=args.repeats,
+        warmups=args.warmups,
+        seed=args.seed,
+        limit=args.limit,
+        device=args.device,
+    )
+    write_json(args.output, result)
+    summary = result["summary"]["overall"]
+    print(
+        f"samples={summary['samples']} p95={summary['latency_ms']['p95']:.1f} ms "
+        f"errors={summary['errors']} empty={summary['empty_predictions']}"
+    )
+    print(f"wrote {args.output}")
+    return result
+
+
+def _score(args: argparse.Namespace) -> list[Path]:
+    values = score_results(
+        [load_json(path) for path in args.results],
+        include_comet=args.comet,
+        comet_batch_size=args.comet_batch_size,
+    )
+    outputs = []
+    for source, value in zip(args.results, values, strict=True):
+        output_dir = args.output_dir or source.parent
+        output = output_dir / f"{source.stem}-scored.json"
+        write_json(output, value)
+        outputs.append(output)
+        print(f"{value['label']}: {format_scored_summary(value)}")
+        print(f"wrote {output}")
+    return outputs
+
+
+def _comparison(args: argparse.Namespace) -> dict[str, Any]:
+    comparison = compare_results(
+        load_json(args.baseline),
+        load_json(args.candidate),
+        bootstrap_iterations=args.bootstrap_iterations,
+        bootstrap_seed=args.bootstrap_seed,
+        min_verified_pairs=args.min_verified_pairs,
+        min_games=args.min_games,
+        min_blind_judgments=args.min_blind_judgments,
+        max_p95_ms=args.max_p95_ms,
+        max_latency_ratio=args.max_latency_ratio,
+        max_artifact_gib=args.max_artifact_gib,
+        max_artifact_ratio=args.max_artifact_ratio,
+        max_game_regression=args.max_game_regression,
+        blind_review=load_json(args.blind_review) if args.blind_review else None,
+        private_holdout_passed=args.private_holdout_passed,
+        license_approved=args.license_approved,
+    )
+    output = args.output or args.candidate.with_name(f"comparison-{args.baseline.stem}-vs-{args.candidate.stem}.json")
+    write_json(output, comparison)
+    delta = comparison["paired_chrfpp"]["delta"]
+    lower, upper = comparison["paired_chrfpp"]["ci95"]
+    print(
+        f"screen chrF++ delta: {delta:+.2f} (95% CI {lower:+.2f} to {upper:+.2f}); "
+        f"outcome={comparison['statistical_outcome']}"
+    )
+    print(f"promotion gate: {'READY' if comparison['promotion_gate']['ready'] else 'NOT READY'}")
+    for blocker in comparison["promotion_gate"]["blockers"]:
+        print(f"  - {blocker}")
+    print(f"wrote {output}")
+    return comparison
+
+
+def _workload_cli(args: argparse.Namespace) -> list[str]:
+    output = [
+        "--sources",
+        str(args.sources),
+        "--reviews",
+        str(args.reviews),
+        "--models",
+        str(args.models),
+        "--data-dir",
+        str(args.data_dir),
+        "--lock",
+        str(args.lock),
+        "--repeats",
+        str(args.repeats),
+        "--warmups",
+        str(args.warmups),
+        "--seed",
+        str(args.seed),
+        "--device",
+        args.device,
+    ]
+    if args.limit is not None:
+        output.extend(["--limit", str(args.limit)])
+    for value in args.tracks or []:
+        output.extend(["--track", value])
+    for value in args.games or []:
+        output.extend(["--game", value])
+    for value in args.text_types or []:
+        output.extend(["--text-type", value])
+    return output
+
+
+def _subprocess_environment(model_id: str) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["PYTHONUTF8"] = "1"
+    environment["TOKENIZERS_PARALLELISM"] = "false"
+    environment["HF_HOME"] = str(
+        (Path(__file__).resolve().parent / ".cache" / "huggingface" / _safe_slug(model_id)).resolve()
+    )
+    environment.pop("HF_HUB_OFFLINE", None)
+    return environment
+
+
+def _uv_run(
+    uv: str,
+    packages: list[str],
+    command: list[str],
+    indexes: list[str] | None = None,
+    index_strategy: str | None = None,
+) -> list[str]:
+    output = [uv, "run", "--isolated", "--no-project"]
+    for index in indexes or []:
+        output.extend(["--index", index])
+    if index_strategy:
+        output.extend(["--index-strategy", index_strategy])
+    for package in packages:
+        output.extend(["--with", package])
+    return [*output, "python", *command]
+
+
+def _matrix(args: argparse.Namespace) -> None:
+    uv = shutil.which("uv")
+    if not uv:
+        raise BenchmarkError("uv is required for isolated candidate and metric environments")
+    _prepare(args)
+    _, model_registry, _ = _load_lock(args)
+    candidates = args.candidates or DEFAULT_CANDIDATES
+    unknown = sorted(set(candidates) - set(model_registry["models"]))
+    if unknown:
+        raise BenchmarkError(f"Unknown candidate model IDs: {', '.join(unknown)}")
+    if "production" in candidates:
+        raise BenchmarkError("production is always the matrix baseline; do not also list it as a candidate")
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime())
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    script = str(Path(__file__).resolve())
+    common = _workload_cli(args)
+    baseline_path = args.results_dir / f"{timestamp}-production.json"
+    print("running exact production baseline", flush=True)
+    subprocess.run(
+        [sys.executable, script, "run", "--model-id", "production", "--output", str(baseline_path), *common],
+        check=True,
+        cwd=REPO_ROOT,
+        env=_subprocess_environment("production"),
+    )
+
+    successful = []
+    failures = {}
+    for model_id in candidates:
+        model = model_registry["models"][model_id]
+        path = args.results_dir / f"{timestamp}-{_safe_slug(model_id)}.json"
+        print(f"running isolated candidate {model_id}", flush=True)
+        command = _uv_run(
+            uv,
+            model["packages"],
+            [script, "run", "--model-id", model_id, "--output", str(path), *common],
+            model.get("uv_indexes"),
+        )
+        completed = subprocess.run(command, cwd=REPO_ROOT, env=_subprocess_environment(model_id), check=False)
+        if completed.returncode:
+            failures[model_id] = {"returncode": completed.returncode, "command": command}
+            print(f"candidate {model_id} failed with exit code {completed.returncode}; continuing", flush=True)
+        elif path.is_file():
+            successful.append(path)
+    if failures:
+        write_json(args.results_dir / f"{timestamp}-failures.json", failures)
+    if not successful:
+        raise BenchmarkError("Every candidate failed; raw production result was preserved")
+
+    metric_packages = ["sacrebleu==2.5.1"]
+    metric_indexes = None
+    score_command = [
+        script,
+        "score",
+        str(baseline_path),
+        *(str(path) for path in successful),
+        "--output-dir",
+        str(args.results_dir),
+        "--comet-batch-size",
+        str(args.comet_batch_size),
+    ]
+    if not args.skip_comet:
+        metric_packages.extend(
+            [
+                "unbabel-comet==2.2.7",
+                "torch==2.9.1",
+                "transformers==4.57.6",
+                "huggingface-hub==0.36.2",
+                "pytorch-lightning==2.6.5",
+                "torchmetrics==0.10.3",
+                "sentencepiece==0.2.2",
+                "numpy==1.26.4",
+                "protobuf==4.25.9",
+                "scipy==1.17.1",
+                "hf-xet==1.6.0",
+                "setuptools==80.9.0",
+            ]
+        )
+        metric_indexes = ["https://download.pytorch.org/whl/cu128"]
+        score_command.append("--comet")
+    subprocess.run(
+        _uv_run(
+            uv,
+            metric_packages,
+            score_command,
+            metric_indexes,
+            "unsafe-best-match" if metric_indexes else None,
+        ),
+        check=True,
+        cwd=REPO_ROOT,
+        env=_subprocess_environment("metrics"),
+    )
+
+    scored_baseline = args.results_dir / f"{baseline_path.stem}-scored.json"
+    for candidate_path in successful:
+        scored_candidate = args.results_dir / f"{candidate_path.stem}-scored.json"
+        comparison_path = args.results_dir / f"{timestamp}-comparison-production-vs-{candidate_path.stem}.json"
+        subprocess.run(
+            _uv_run(
+                uv,
+                ["sacrebleu==2.5.1"],
+                [
+                    script,
+                    "compare",
+                    str(scored_baseline),
+                    str(scored_candidate),
+                    "--output",
+                    str(comparison_path),
+                    "--bootstrap-iterations",
+                    str(args.bootstrap_iterations),
+                ],
+            ),
+            check=True,
+            cwd=REPO_ROOT,
+            env=_subprocess_environment("metrics"),
+        )
+    print(f"matrix results: {args.results_dir}")
+
+
+def _cache_audit(lock: dict[str, Any], threshold: float) -> dict[str, Any]:
+    if not 0 <= threshold <= 1:
+        raise BenchmarkError("cache threshold must be between 0 and 1")
+    samples = [sample for sample in lock["samples"] if sample["track"] == "screen"]
+    collisions = []
+    for index, first in enumerate(samples):
+        for second in samples[index + 1 :]:
+            ratio = difflib.SequenceMatcher(None, first["source"], second["source"]).ratio()
+            if ratio < threshold:
+                continue
+            if {comparison_text(value) for value in first["references"]} == {
+                comparison_text(value) for value in second["references"]
+            }:
+                continue
+            collisions.append(
+                {
+                    "similarity": ratio,
+                    "first": {key: first[key] for key in ("id", "game", "source", "references")},
+                    "second": {key: second[key] for key in ("id", "game", "source", "references")},
+                }
+            )
+    collisions.sort(key=lambda item: (-item["similarity"], item["first"]["id"], item["second"]["id"]))
+    return {
+        "schema_version": 1,
+        "threshold": threshold,
+        "screen_samples": len(samples),
+        "potential_collisions": len(collisions),
+        "note": "Static worst-case diagnostic; runtime collisions also depend on cache contents and insertion order.",
+        "collisions": collisions,
+    }
+
+
+def main() -> int:
+    _configure_console_utf8()
+    args = build_parser().parse_args()
+    try:
+        if args.command == "prepare":
+            _prepare(args)
+        elif args.command == "inventory":
+            lock, _, _ = _load_lock(args)
+            _print_inventory(inventory(lock))
+        elif args.command == "validate":
+            lock, _, _ = _load_lock(args)
+            print(f"valid corpus fingerprint: {fingerprint(lock)}")
+        elif args.command == "run":
+            _run(args)
+        elif args.command == "score":
+            _score(args)
+        elif args.command == "compare":
+            _comparison(args)
+        elif args.command == "matrix":
+            _matrix(args)
+        elif args.command == "blind-packet":
+            report = create_blind_packet(
+                load_json(args.baseline),
+                load_json(args.candidate),
+                packet_path=args.packet,
+                key_path=args.key,
+                track=args.track,
+                limit=args.limit,
+                seed=args.seed,
+            )
+            print(f"wrote {report['rows']} blind rows to {report['packet']}")
+            print(f"keep the model key separate from reviewers: {report['key']}")
+        elif args.command == "blind-score":
+            report = score_blind_packet(args.packet, load_json(args.key))
+            write_json(args.output, report)
+            print(f"scored {report['judgments']} judgments; wrote {args.output}")
+        elif args.command == "reference-packet":
+            lock, _, _ = _load_lock(args)
+            count = create_reference_packet(lock, packet_path=args.packet, limit=args.limit, seed=args.seed)
+            print(f"wrote {count} pre-output reference review rows to {args.packet}")
+        elif args.command == "cache-audit":
+            lock, _, _ = _load_lock(args)
+            report = _cache_audit(lock, args.threshold)
+            if args.output:
+                write_json(args.output, report)
+                print(f"wrote {args.output}")
+            print(f"potential fuzzy-cache collisions: {report['potential_collisions']}")
+        return 0
+    except BenchmarkError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as exc:
+        print(f"error: subprocess failed with exit code {exc.returncode}", file=sys.stderr)
+        return exc.returncode or 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/translation/corpus.py
+++ b/benchmark/translation/corpus.py
@@ -1,0 +1,614 @@
+"""Download, parse, freeze, and validate the translation corpus."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import urllib.error
+import urllib.request
+import zipfile
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+from benchlib import (
+    BenchmarkError,
+    apply_reviews,
+    collapse_whitespace,
+    comparison_text,
+    expand_tracks,
+    fingerprint,
+    has_japanese,
+    length_bucket,
+    select_entries,
+    sha256_file,
+    validate_reviews,
+    validate_source_registry,
+    write_json,
+)
+
+_PS_ALLOWED_TAG_RE = re.compile(r"<(?:line|wait(?: more)?|end|delay)>", re.IGNORECASE)
+_PS_ANY_TAG_RE = re.compile(r"<[^>]+>")
+_METAL_CODE_RE = re.compile(r"\(CODE [^)]+\)", re.IGNORECASE)
+_METAL_LINE_WIDTH_RE = re.compile(r"\\LineWidth(?:=\d+|PortraitShowing)/", re.IGNORECASE)
+_METAL_LAYOUT_RE = re.compile(
+    r"\((?:LINE|STOP|WAIT|PAUSE|DELAY|End quote|Start quote)[^)]*\)",
+    re.IGNORECASE,
+)
+_METAL_HEX_RE = re.compile(r"\{[0-9A-Fa-f]{2}\}")
+_METAL_VISIBLE_BRACKET_RE = re.compile(r"\[([！？!?…]+)\]")
+_METAL_OTHER_BRACKET_RE = re.compile(r"\[[^]]+\]")
+_METAL_OTHER_CONTROL_RE = re.compile(r"\([^)]*\)")
+_BOX_DRAWING_RE = re.compile(r"[\u2500-\u257f]")
+_MENU_METADATA_RE = re.compile(r"\b(?:option|choice|menu|select)\b", re.IGNORECASE)
+_DS6_CONTROL_RE = re.compile(r"<[^>]+>")
+_DS6_LAYOUT_RE = re.compile(r"X{2,}")
+_DS6_ALLOWED_CONTROL_RE = re.compile(
+    r"(?:X(?:1e|04|0a|08)|RET_IL|RETN|CH[0-9A-Fa-f]+|END|WAIT|PAGE|P|N)",
+    re.IGNORECASE,
+)
+
+
+def _source_path(data_dir: Path, source_id: str, role: str, remote_path: str) -> Path:
+    safe_name = Path(remote_path).name
+    return data_dir / "sources" / source_id / f"{role}-{safe_name}"
+
+
+def _download(url: str, destination: Path, expected_sha256: str) -> dict[str, Any]:
+    if destination.is_file():
+        actual = sha256_file(destination)
+        if actual == expected_sha256:
+            return {"sha256": actual, "bytes": destination.stat().st_size}
+        raise BenchmarkError(
+            f"Existing source has the wrong hash: {destination}. Remove that one file and run prepare again."
+        )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".part")
+    request = urllib.request.Request(url, headers={"User-Agent": "interpreter-translation-benchmark/1"})
+    try:
+        with urllib.request.urlopen(request, timeout=90) as response, temporary.open("wb") as output:
+            while chunk := response.read(1024 * 1024):
+                output.write(chunk)
+    except (OSError, urllib.error.URLError) as exc:
+        if temporary.exists():
+            temporary.unlink()
+        raise BenchmarkError(f"Could not download {url}: {exc}") from exc
+
+    actual = sha256_file(temporary)
+    if actual != expected_sha256:
+        temporary.unlink()
+        raise BenchmarkError(f"Downloaded source hash mismatch for {url}: expected {expected_sha256}, got {actual}")
+    temporary.replace(destination)
+    return {"sha256": actual, "bytes": destination.stat().st_size}
+
+
+def _clean_reference(text: str | None) -> str:
+    return collapse_whitespace(text)
+
+
+def _clean_phantasy(text: str | None, *, menu: bool = False) -> str:
+    if not text:
+        return ""
+    without_layout = _PS_ALLOWED_TAG_RE.sub(" ", text).replace("~", " ")
+    # Runtime substitutions such as <player>, <item>, and <number> are not
+    # recoverable from a static script and therefore are not valid screenshots.
+    if _PS_ANY_TAG_RE.search(without_layout):
+        return ""
+    if menu:
+        without_layout = _BOX_DRAWING_RE.sub(" ", without_layout)
+        without_layout = without_layout.replace("------", " ")
+    return collapse_whitespace(without_layout)
+
+
+def _clean_metal(text: str | None) -> str:
+    value = text or ""
+    value = _METAL_LINE_WIDTH_RE.sub(" ", value)
+    value = _METAL_CODE_RE.sub(" ", value)
+    value = _METAL_LAYOUT_RE.sub(" ", value)
+    value = _METAL_HEX_RE.sub(" ", value)
+    value = _METAL_VISIBLE_BRACKET_RE.sub(r"\1", value)
+    value = _METAL_OTHER_BRACKET_RE.sub(" ", value)
+    value = _METAL_OTHER_CONTROL_RE.sub(" ", value)
+    return collapse_whitespace(value)
+
+
+def _clean_ds6(text: str | None) -> str:
+    value = _DS6_CONTROL_RE.sub(" ", text or "")
+    value = _DS6_LAYOUT_RE.sub(" ", value)
+    return collapse_whitespace(value)
+
+
+def _valid_ds6_record(screen_raw: str, reference_raw: str, screen: str, reference: str) -> bool:
+    # The script interleaves text with branches, subroutine calls, and runtime
+    # substitutions. Only retain linear records whose controls are known to be
+    # layout/speaker markers; otherwise the static text is not what OCR sees.
+    controls = [
+        match.group(0)[1:-1] for value in (screen_raw, reference_raw) for match in _DS6_CONTROL_RE.finditer(value)
+    ]
+    if any(not _DS6_ALLOWED_CONTROL_RE.fullmatch(control) for control in controls):
+        return False
+    if has_japanese(reference) or not re.search(r"[A-Za-z]", reference):
+        return False
+    if re.search(r"\b(?:TODO|TBD|UNTRANSLATED)\b", reference, re.IGNORECASE):
+        return False
+    # One combat bank contains an internal numbered-file diagnostic. It is
+    # translated in the repository, but is test content rather than game text.
+    if "ファイル" in screen and re.search(r"[ＭM][ー－−-][０-９0-9]+", screen):
+        return False
+    if re.search(r"\bthis file is\s+M-\d+\b", reference, re.IGNORECASE):
+        return False
+    # Some combat rows rely on the engine prepending an actor name without an
+    # explicit control code in the CSV. A leading standalone particle exposes
+    # the otherwise-invisible substitution and makes the row context-incomplete.
+    if re.match(r"^(?:は|が|を|に|へ|と|の|も)\s", screen):
+        return False
+    return len(reference) <= max(40, len(screen) * 6)
+
+
+def _references(*values: str) -> list[str]:
+    output = []
+    seen = set()
+    for value in values:
+        cleaned = _clean_reference(value)
+        normalized = comparison_text(cleaned)
+        if cleaned and normalized not in seen:
+            seen.add(normalized)
+            output.append(cleaned)
+    return output
+
+
+def _entry(
+    source: dict[str, Any],
+    source_index: str,
+    text_type: str,
+    screen: str,
+    normalized: str,
+    references: list[str],
+    registry: dict[str, Any],
+    source_file_roles: list[str],
+) -> dict[str, Any] | None:
+    screen = collapse_whitespace(screen)
+    normalized = collapse_whitespace(normalized)
+    references = _references(*references)
+    maximum = registry["maximum_source_characters"]
+    if not screen or not has_japanese(screen) or not references:
+        return None
+    if len(screen.replace(" ", "")) > maximum:
+        return None
+    if any(comparison_text(screen) == comparison_text(reference) for reference in references):
+        return None
+    bucket = length_bucket(screen, registry["length_buckets"])
+    return {
+        "pair_id": f"{source['id']}:{source_index}",
+        "source_id": source["id"],
+        "source_index": source_index,
+        "game": source["game"],
+        "platform": source["platform"],
+        "release_year": source["release_year"],
+        "genre": source["genre"],
+        "text_type": text_type,
+        "length_bucket": bucket,
+        "screen": screen,
+        "normalized": normalized or None,
+        "references": references,
+        "reference_status": source["reference_status"],
+        "provenance": {
+            "repository": source["repository"],
+            "commit": source["commit"],
+            "page_url": source["provenance_url"],
+            "file_roles": source_file_roles,
+            "license": source["license"],
+        },
+    }
+
+
+def _parse_nintendo_messages(
+    source: dict[str, Any], path: Path, registry: dict[str, Any], *, fixed: bool
+) -> list[dict[str, Any]]:
+    lines = path.read_text(encoding="utf-8-sig").splitlines()
+    blocks: list[tuple[list[str], list[str], list[str]]] = []
+    if fixed:
+        if len(lines) % 12:
+            raise BenchmarkError(f"{path} no longer consists of 12-line message records")
+        for start in range(0, len(lines), 12):
+            block = lines[start : start + 12]
+            blocks.append((block[:4], block[4:8], block[8:12]))
+    else:
+        index = 0
+        while index < len(lines):
+            header = lines[index].split()
+            if not header or not header[0].isdigit():
+                raise BenchmarkError(f"Malformed variable message header in {path} at line {index + 1}")
+            count = int(header[0])
+            index += 1
+            block = lines[index : index + count * 3]
+            if len(block) != count * 3:
+                raise BenchmarkError(f"Truncated variable message record in {path} at line {index + 1}")
+            blocks.append((block[:count], block[count : count * 2], block[count * 2 :]))
+            index += count * 3
+
+    output = []
+    for index, (screen, normalized, reference) in enumerate(blocks):
+        parsed = _entry(
+            source,
+            f"message-{index:06d}",
+            "dialogue",
+            "\n".join(screen),
+            "\n".join(normalized),
+            ["\n".join(reference)],
+            registry,
+            ["messages"],
+        )
+        if parsed:
+            output.append(parsed)
+    return output
+
+
+def _parse_nintendo_options(source: dict[str, Any], path: Path, registry: dict[str, Any]) -> list[dict[str, Any]]:
+    lines = path.read_text(encoding="utf-8-sig").splitlines()
+    if len(lines) % 2:
+        raise BenchmarkError(f"{path} no longer consists of alternating Japanese/English option records")
+    output = []
+    for index in range(0, len(lines), 2):
+        parsed = _entry(
+            source,
+            f"option-{index // 2:06d}",
+            "menu",
+            lines[index],
+            "",
+            [lines[index + 1]],
+            registry,
+            ["options"],
+        )
+        if parsed:
+            output.append(parsed)
+    return output
+
+
+def _load_yaml(path: Path) -> Any:
+    try:
+        import yaml
+    except ImportError as exc:
+        raise BenchmarkError(
+            "Preparing the Phantasy Star corpus requires PyYAML (already an Interpreter dependency)"
+        ) from exc
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8-sig"))
+    except yaml.YAMLError as exc:
+        raise BenchmarkError(f"Invalid YAML source {path}: {exc}") from exc
+
+
+def _parse_phantasy_star(
+    source: dict[str, Any], paths: dict[str, Path], registry: dict[str, Any]
+) -> list[dict[str, Any]]:
+    output = []
+    messages = _load_yaml(paths["messages"])
+    if not isinstance(messages, list):
+        raise BenchmarkError(f"Expected a YAML list in {paths['messages']}")
+    for index, value in enumerate(messages):
+        if not isinstance(value, dict):
+            continue
+        screen = _clean_phantasy(value.get("ja"))
+        normalized = _clean_phantasy(value.get("kanji"))
+        references = [_clean_phantasy(value.get("literal")), _clean_phantasy(value.get("us"))]
+        parsed = _entry(
+            source,
+            f"message-{index:06d}",
+            "dialogue",
+            screen,
+            normalized,
+            references,
+            registry,
+            ["messages"],
+        )
+        if parsed:
+            output.append(parsed)
+
+    menus = _load_yaml(paths["options"])
+    if not isinstance(menus, list):
+        raise BenchmarkError(f"Expected a YAML list in {paths['options']}")
+    for index, value in enumerate(menus):
+        if not isinstance(value, dict):
+            continue
+        screen = _clean_phantasy(value.get("jp"), menu=True)
+        normalized = _clean_phantasy(value.get("kanji"), menu=True)
+        references = [
+            _clean_phantasy(value.get("literal"), menu=True),
+            _clean_phantasy(value.get("us"), menu=True),
+        ]
+        parsed = _entry(
+            source,
+            f"menu-{index:06d}",
+            "menu",
+            screen,
+            normalized,
+            references,
+            registry,
+            ["options"],
+        )
+        if parsed:
+            output.append(parsed)
+    return output
+
+
+def _walk_metal(value: Any, path: str = ""):
+    if isinstance(value, dict):
+        if "Original" in value and "New" in value:
+            yield path, value
+        else:
+            for key, child in value.items():
+                yield from _walk_metal(child, f"{path}/{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _walk_metal(child, f"{path}/{index}")
+
+
+def _parse_metal_slader(source: dict[str, Any], path: Path, registry: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8-sig"))
+        dialogue = value["indexTable"]["Dialogue"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise BenchmarkError(f"Metal Slader source structure changed in {path}") from exc
+
+    output = []
+    for index, (json_path, text) in enumerate(_walk_metal(dialogue)):
+        screen = _clean_metal(text.get("Original"))
+        reference = _clean_metal(text.get("New"))
+        metadata = collapse_whitespace(text.get("Menu"))
+        # Debug labels describe sound effects, room transitions, portrait tests,
+        # and other development metadata; they are not player-visible text.
+        if re.search(r"\bdebug\b", metadata, re.IGNORECASE):
+            continue
+        text_type = "menu" if _MENU_METADATA_RE.search(metadata) else "dialogue"
+        parsed = _entry(
+            source,
+            f"dialogue-{index:06d}",
+            text_type,
+            screen,
+            "",
+            [reference],
+            registry,
+            ["messages"],
+        )
+        if parsed:
+            parsed["provenance"]["record_path"] = json_path
+            parsed["provenance"]["record_category"] = metadata
+            output.append(parsed)
+    return output
+
+
+def _parse_ds6(source: dict[str, Any], path: Path, registry: dict[str, Any]) -> list[dict[str, Any]]:
+    try:
+        archive = zipfile.ZipFile(path)
+    except zipfile.BadZipFile as exc:
+        raise BenchmarkError(f"Dragon Slayer source is not a valid ZIP archive: {path}") from exc
+
+    members = sorted(
+        name
+        for name in archive.namelist()
+        if "/csv/" in name and name.casefold().endswith(".csv") and not name.endswith("/")
+    )
+    if not members:
+        raise BenchmarkError(f"Dragon Slayer archive contains no csv/*.csv files: {path}")
+
+    output = []
+    with archive:
+        for member in members:
+            relative = member.split("/csv/", 1)[1]
+            if relative.startswith("Scenarios/") or relative in {"Opening.csv", "Ending.csv"}:
+                text_type = "dialogue"
+            elif relative.startswith("Combats/"):
+                text_type = "system"
+            elif relative in {"Items.csv", "Locations.csv", "Spells.csv"}:
+                text_type = "menu"
+            else:
+                continue
+            try:
+                rows = csv.reader(io.StringIO(archive.read(member).decode("utf-8-sig")))
+                for row_index, row in enumerate(rows):
+                    if len(row) != 3 or row[0] == "*":
+                        continue
+                    screen = _clean_ds6(row[1])
+                    reference = _clean_ds6(row[2])
+                    if not _valid_ds6_record(row[1], row[2], screen, reference):
+                        continue
+                    stem = Path(relative).stem.replace(".", "-")
+                    parsed = _entry(
+                        source,
+                        f"{text_type}-{stem}-{row_index:04d}",
+                        text_type,
+                        screen,
+                        "",
+                        [reference],
+                        registry,
+                        ["archive"],
+                    )
+                    if parsed:
+                        parsed["provenance"]["record_path"] = relative
+                        parsed["provenance"]["record_id"] = row[0]
+                        output.append(parsed)
+            except (UnicodeDecodeError, csv.Error) as exc:
+                raise BenchmarkError(f"Could not parse {member} in {path}: {exc}") from exc
+    return output
+
+
+def _deduplicate_context_free(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove duplicate and ambiguous labels within one game/source.
+
+    Interpreter currently translates one capture without dialogue history. If
+    identical visible Japanese has conflicting references inside a game, there
+    is no context-free gold answer and all occurrences are excluded.
+    """
+
+    groups: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for entry in entries:
+        groups[(entry["source_id"], comparison_text(entry["screen"]))].append(entry)
+
+    output = []
+    for group in groups.values():
+        reference_sets = {tuple(comparison_text(value) for value in entry["references"]) for entry in group}
+        if len(reference_sets) > 1:
+            continue
+        output.append(min(group, key=lambda item: item["pair_id"]))
+    return sorted(output, key=lambda item: item["pair_id"])
+
+
+def prepare_corpus(
+    registry: dict[str, Any],
+    reviews: dict[str, Any],
+    data_dir: Path,
+    registry_path: Path,
+    reviews_path: Path,
+) -> dict[str, Any]:
+    errors = [*validate_source_registry(registry), *validate_reviews(reviews)]
+    if errors:
+        raise BenchmarkError("Corpus configuration is invalid:\n- " + "\n- ".join(errors))
+
+    source_files: dict[str, Any] = {}
+    parsed_entries = []
+    for source in registry["sources"]:
+        print(f"preparing {source['game']}")
+        paths: dict[str, Path] = {}
+        metadata_by_role = {}
+        for role, metadata in source["files"].items():
+            destination = _source_path(data_dir, source["id"], role, metadata["path"])
+            local = _download(metadata["url"], destination, metadata["sha256"])
+            paths[role] = destination
+            metadata_by_role[role] = {
+                "path": destination.relative_to(data_dir).as_posix(),
+                "url": metadata["url"],
+                **local,
+            }
+        source_files[source["id"]] = metadata_by_role
+
+        parser = source["parser"]
+        if parser in {"nintendo_fixed", "nintendo_variable"}:
+            parsed_entries.extend(
+                _parse_nintendo_messages(source, paths["messages"], registry, fixed=parser == "nintendo_fixed")
+            )
+            if "options" in paths:
+                parsed_entries.extend(_parse_nintendo_options(source, paths["options"], registry))
+        elif parser == "phantasy_star":
+            parsed_entries.extend(_parse_phantasy_star(source, paths, registry))
+        elif parser == "metal_slader":
+            parsed_entries.extend(_parse_metal_slader(source, paths["messages"], registry))
+        elif parser == "ds6_pc98":
+            parsed_entries.extend(_parse_ds6(source, paths["archive"], registry))
+        else:
+            raise BenchmarkError(f"Unknown corpus parser: {parser}")
+
+    eligible = _deduplicate_context_free(parsed_entries)
+    eligible = apply_reviews(eligible, reviews)
+    selected = select_entries(eligible, registry)
+    samples = expand_tracks(selected)
+
+    lock = {
+        "schema_version": 1,
+        "corpus_id": registry["corpus_id"],
+        "source_registry": registry_path.name,
+        "source_registry_sha256": fingerprint(registry),
+        "reviews": reviews_path.name,
+        "reviews_sha256": fingerprint(reviews),
+        "sampling_seed": registry["sampling_seed"],
+        "length_buckets": registry["length_buckets"],
+        "maximum_source_characters": registry["maximum_source_characters"],
+        "source_files": source_files,
+        "eligible_pairs": len(eligible),
+        "pairs": selected,
+        "samples": samples,
+    }
+    errors = validate_lock(lock, data_dir, check_files=True)
+    if errors:
+        raise BenchmarkError("Generated corpus lock is invalid:\n- " + "\n- ".join(errors))
+    write_json(data_dir / "corpus.lock.json", lock)
+    return lock
+
+
+def validate_lock(lock: dict[str, Any], data_dir: Path, *, check_files: bool) -> list[str]:
+    errors: list[str] = []
+    if lock.get("schema_version") != 1:
+        errors.append("lock schema_version must be 1")
+    pairs = lock.get("pairs")
+    samples = lock.get("samples")
+    if not isinstance(pairs, list) or not pairs:
+        errors.append("lock pairs must be a non-empty list")
+    if not isinstance(samples, list) or not samples:
+        errors.append("lock samples must be a non-empty list")
+        return errors
+
+    ids = [sample.get("id") for sample in samples if isinstance(sample, dict)]
+    duplicates = sorted(value for value, count in Counter(ids).items() if count > 1)
+    if duplicates:
+        errors.append(f"duplicate sample IDs: {', '.join(duplicates)}")
+    for index, sample in enumerate(samples):
+        prefix = f"samples[{index}]"
+        if not isinstance(sample, dict):
+            errors.append(f"{prefix} must be an object")
+            continue
+        for field in ("id", "pair_id", "source_id", "game", "source", "track", "text_type", "length_bucket"):
+            if not isinstance(sample.get(field), str) or not sample[field]:
+                errors.append(f"{prefix}.{field} must be a non-empty string")
+        if sample.get("track") not in {"screen", "normalized"}:
+            errors.append(f"{prefix}.track is invalid")
+        if not has_japanese(sample.get("source")):
+            errors.append(f"{prefix}.source has no Japanese text")
+        references = sample.get("references")
+        if not isinstance(references, list) or not references or not all(isinstance(x, str) and x for x in references):
+            errors.append(f"{prefix}.references must be a non-empty string list")
+
+    source_files = lock.get("source_files")
+    if not isinstance(source_files, dict):
+        errors.append("lock source_files must be an object")
+    elif check_files:
+        for source_id, roles in source_files.items():
+            if not isinstance(roles, dict):
+                errors.append(f"source_files.{source_id} must be an object")
+                continue
+            for role, metadata in roles.items():
+                path = data_dir / metadata.get("path", "")
+                if not path.is_file():
+                    errors.append(f"missing source file: {path}")
+                elif sha256_file(path) != metadata.get("sha256"):
+                    errors.append(f"source file hash changed: {source_id}/{role}")
+    return errors
+
+
+def load_and_validate_lock(
+    lock_path: Path,
+    data_dir: Path,
+    registry: dict[str, Any],
+    reviews: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"Corpus lock not found: {lock_path}. Run prepare first.") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkError(f"Invalid corpus lock {lock_path}: {exc}") from exc
+    if lock.get("source_registry_sha256") != fingerprint(registry):
+        raise BenchmarkError("Corpus lock does not match sources.json; run prepare again")
+    if lock.get("reviews_sha256") != fingerprint(reviews):
+        raise BenchmarkError("Corpus lock does not match reviews.json; run prepare again")
+    errors = validate_lock(lock, data_dir, check_files=True)
+    if errors:
+        raise BenchmarkError("Corpus lock validation failed:\n- " + "\n- ".join(errors))
+    return lock
+
+
+def inventory(lock: dict[str, Any]) -> dict[str, Any]:
+    pairs = lock["pairs"]
+    samples = lock["samples"]
+    return {
+        "eligible_pairs": lock["eligible_pairs"],
+        "selected_pairs": len(pairs),
+        "samples": len(samples),
+        "verified_pairs": sum(bool(pair["independently_verified"]) for pair in pairs),
+        "games": dict(sorted(Counter(pair["game"] for pair in pairs).items())),
+        "platforms": dict(sorted(Counter(pair["platform"] for pair in pairs).items())),
+        "text_types": dict(sorted(Counter(pair["text_type"] for pair in pairs).items())),
+        "length_buckets": dict(sorted(Counter(pair["length_bucket"] for pair in pairs).items())),
+        "tracks": dict(sorted(Counter(sample["track"] for sample in samples).items())),
+    }

--- a/benchmark/translation/corpus.py
+++ b/benchmark/translation/corpus.py
@@ -89,6 +89,12 @@ def _clean_reference(text: str | None) -> str:
     return collapse_whitespace(text)
 
 
+def _clean_nintendo(text: str | None) -> str:
+    # The source projects' game writers explicitly discard U+FF5C. It marks a
+    # layout boundary in the dump and is never drawn as a player-visible glyph.
+    return collapse_whitespace((text or "").replace("｜", " "))
+
+
 def _clean_phantasy(text: str | None, *, menu: bool = False) -> str:
     if not text:
         return ""
@@ -236,9 +242,9 @@ def _parse_nintendo_messages(
             source,
             f"message-{index:06d}",
             "dialogue",
-            "\n".join(screen),
-            "\n".join(normalized),
-            ["\n".join(reference)],
+            _clean_nintendo("\n".join(screen)),
+            _clean_nintendo("\n".join(normalized)),
+            [_clean_nintendo("\n".join(reference))],
             registry,
             ["messages"],
         )
@@ -257,9 +263,9 @@ def _parse_nintendo_options(source: dict[str, Any], path: Path, registry: dict[s
             source,
             f"option-{index // 2:06d}",
             "menu",
-            lines[index],
+            _clean_nintendo(lines[index]),
             "",
-            [lines[index + 1]],
+            [_clean_nintendo(lines[index + 1])],
             registry,
             ["options"],
         )

--- a/benchmark/translation/metrics.py
+++ b/benchmark/translation/metrics.py
@@ -26,6 +26,11 @@ COMET_ENCODER_REPO_ID = "xlm-roberta-large"
 COMET_ENCODER_REVISION = "c23d21b0620b635a76227c604d44e43a9f0ee389"
 
 
+def _scoring_source_metadata() -> dict[str, str]:
+    directory = Path(__file__).resolve().parent
+    return {name: sha256_file(directory / name) for name in ("benchlib.py", "metrics.py")}
+
+
 def _sacrebleu_metrics():
     try:
         import sacrebleu
@@ -213,6 +218,7 @@ def score_results(
         result["metrics"] = {
             "scored_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
             "source_sha256": sha256_file(Path(__file__)),
+            "source_files_sha256": _scoring_source_metadata(),
             "primary": "macro mean of per-sample chrF++ against all available references",
             "secondary": "first-reference corpus chrF++ and BLEU; optional reference-based COMET",
             "versions": versions,
@@ -307,6 +313,16 @@ def _validate_comparison_contract(baseline: dict[str, Any], candidate: dict[str,
     candidate_records = [{field: sample.get(field) for field in identity_fields} for sample in candidate["samples"]]
     if baseline_records != candidate_records:
         raise BenchmarkError("Cannot compare reports whose ordered sample records differ")
+
+    baseline_has_comet = any("comet" in sample.get("metrics", {}) for sample in baseline["samples"])
+    candidate_has_comet = any("comet" in sample.get("metrics", {}) for sample in candidate["samples"])
+    if baseline_has_comet != candidate_has_comet:
+        raise BenchmarkError("Cannot compare reports when only one contains COMET sample scores")
+    if baseline_has_comet:
+        baseline_comet = baseline.get("metrics", {}).get("comet")
+        candidate_comet = candidate.get("metrics", {}).get("comet")
+        if not baseline_comet or fingerprint(baseline_comet) != fingerprint(candidate_comet):
+            raise BenchmarkError("Cannot compare reports scored with different COMET configurations")
 
 
 def _outcome(paired: dict[str, Any]) -> str:

--- a/benchmark/translation/metrics.py
+++ b/benchmark/translation/metrics.py
@@ -1,0 +1,548 @@
+"""Standard MT scoring and fail-closed paired model comparison."""
+
+from __future__ import annotations
+
+import copy
+import importlib.metadata
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+from benchlib import (
+    BenchmarkError,
+    bootstrap_mean_delta,
+    comparison_text,
+    fingerprint,
+    has_japanese,
+    latency_summary,
+    number_preservation,
+    sha256_file,
+)
+
+COMET_REPO_ID = "Unbabel/wmt22-comet-da"
+COMET_REVISION = "2760a223ac957f30acfb18c8aa649b01cf1d75f2"
+COMET_ENCODER_REPO_ID = "xlm-roberta-large"
+COMET_ENCODER_REVISION = "c23d21b0620b635a76227c604d44e43a9f0ee389"
+
+
+def _sacrebleu_metrics():
+    try:
+        import sacrebleu
+        from sacrebleu.metrics import BLEU, CHRF
+    except ImportError as exc:
+        raise BenchmarkError(
+            "Scoring requires sacrebleu==2.5.1. Use the documented uv isolated score/compare command."
+        ) from exc
+    return sacrebleu, BLEU(effective_order=True), CHRF(word_order=2)
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _score_samples(samples: list[dict[str, Any]]) -> tuple[Any, Any, Any]:
+    sacrebleu, bleu, chrf = _sacrebleu_metrics()
+    for sample in samples:
+        prediction = sample.get("prediction", "")
+        references = sample["references"]
+        comet = sample.get("metrics", {}).get("comet")
+        sample["metrics"] = {
+            "chrfpp": chrf.sentence_score(prediction, references).score,
+            "bleu": bleu.sentence_score(prediction, references).score,
+            "exact_reference_match": any(
+                comparison_text(prediction) == comparison_text(reference) for reference in references
+            ),
+        }
+        if comet is not None:
+            sample["metrics"]["comet"] = comet
+    return sacrebleu, bleu, chrf
+
+
+def _slice_summary(samples: list[dict[str, Any]], bleu: Any, chrf: Any) -> dict[str, Any]:
+    if not samples:
+        return {"samples": 0, "macro_sentence_chrfpp": None, "corpus_chrfpp": None, "corpus_bleu": None}
+    predictions = [sample.get("prediction", "") for sample in samples]
+    primary_references = [[sample["references"][0] for sample in samples]]
+    numeric_preserved = numeric_total = 0
+    for sample in samples:
+        preserved, total = number_preservation(sample["source"], sample.get("prediction", ""))
+        numeric_preserved += preserved
+        numeric_total += total
+    comet_values = [sample["metrics"]["comet"] for sample in samples if "comet" in sample["metrics"]]
+    return {
+        "samples": len(samples),
+        "macro_sentence_chrfpp": statistics.fmean(sample["metrics"]["chrfpp"] for sample in samples),
+        "macro_sentence_bleu": statistics.fmean(sample["metrics"]["bleu"] for sample in samples),
+        "corpus_chrfpp": chrf.corpus_score(predictions, primary_references).score,
+        "corpus_bleu": bleu.corpus_score(predictions, primary_references).score,
+        "comet": statistics.fmean(comet_values) if len(comet_values) == len(samples) else None,
+        "exact_reference_matches": sum(sample["metrics"]["exact_reference_match"] for sample in samples),
+        "errors": sum(bool(sample.get("errors")) for sample in samples),
+        "empty_predictions": sum(not sample.get("prediction", "").strip() for sample in samples),
+        "japanese_leakage": sum(has_japanese(sample.get("prediction")) for sample in samples),
+        "nondeterministic_samples": sum(sample.get("unique_predictions", 0) > 1 for sample in samples),
+        "number_preservation": {
+            "preserved": numeric_preserved,
+            "total": numeric_total,
+            "rate": numeric_preserved / numeric_total if numeric_total else None,
+        },
+        "latency_ms": latency_summary(samples),
+    }
+
+
+def _summaries(samples: list[dict[str, Any]], bleu: Any, chrf: Any) -> dict[str, Any]:
+    dimensions = {}
+    for field in ("track", "game", "platform", "text_type", "length_bucket"):
+        dimensions[field] = {
+            value: _slice_summary([sample for sample in samples if sample[field] == value], bleu, chrf)
+            for value in sorted({sample[field] for sample in samples})
+        }
+    return {"overall": _slice_summary(samples, bleu, chrf), "by": dimensions}
+
+
+def _load_comet():
+    try:
+        import torch
+        from comet import load_from_checkpoint
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise BenchmarkError(
+            "COMET scoring requires unbabel-comet and huggingface-hub in the isolated metric environment"
+        ) from exc
+    model_dir = Path(
+        snapshot_download(
+            repo_id=COMET_REPO_ID,
+            revision=COMET_REVISION,
+            allow_patterns=["checkpoints/model.ckpt", "hparams.yaml"],
+        )
+    )
+    encoder_dir = Path(
+        snapshot_download(
+            repo_id=COMET_ENCODER_REPO_ID,
+            revision="main",
+            allow_patterns=[
+                "config.json",
+                "sentencepiece.bpe.model",
+                "tokenizer.json",
+                "tokenizer_config.json",
+            ],
+        )
+    )
+    if encoder_dir.name != COMET_ENCODER_REVISION:
+        raise BenchmarkError(
+            f"{COMET_ENCODER_REPO_ID} main resolved to {encoder_dir.name}; expected {COMET_ENCODER_REVISION}"
+        )
+    checkpoint = model_dir / "checkpoints" / "model.ckpt"
+    model = load_from_checkpoint(str(checkpoint), local_files_only=True)
+    return torch, model, model_dir, encoder_dir
+
+
+def _comet_scores(model: Any, torch: Any, samples: list[dict[str, Any]], batch_size: int) -> list[float]:
+    data = [
+        {"src": sample["source"], "mt": sample.get("prediction", ""), "ref": sample["references"][0]}
+        for sample in samples
+    ]
+    prediction = model.predict(data, batch_size=batch_size, gpus=1 if torch.cuda.is_available() else 0)
+    scores = getattr(prediction, "scores", None)
+    if scores is None and isinstance(prediction, tuple):
+        scores = prediction[0]
+    if scores is None:
+        raise BenchmarkError("COMET returned an unrecognized prediction object")
+    output = [float(value) for value in scores]
+    if len(output) != len(samples):
+        raise BenchmarkError(f"COMET returned {len(output)} scores for {len(samples)} samples")
+    return output
+
+
+def score_results(
+    results: list[dict[str, Any]],
+    *,
+    include_comet: bool = False,
+    comet_batch_size: int = 16,
+) -> list[dict[str, Any]]:
+    """Score one or more raw results, sharing a single optional COMET load."""
+
+    scored = [copy.deepcopy(result) for result in results]
+    versions: dict[str, Any] = {}
+    for result in scored:
+        if result.get("schema_version") != 1 or not isinstance(result.get("samples"), list):
+            raise BenchmarkError("Result is not a translation benchmark schema-v1 report")
+        sacrebleu, bleu, chrf = _score_samples(result["samples"])
+        versions = {
+            "sacrebleu": getattr(sacrebleu, "__version__", _package_version("sacrebleu")),
+            "bleu_signature": str(bleu.get_signature()),
+            "chrfpp_signature": str(chrf.get_signature()),
+        }
+
+    comet_metadata = None
+    if include_comet:
+        torch, comet_model, model_dir, encoder_dir = _load_comet()
+        for result in scored:
+            values = _comet_scores(comet_model, torch, result["samples"], comet_batch_size)
+            for sample, value in zip(result["samples"], values, strict=True):
+                sample["metrics"]["comet"] = value
+        comet_metadata = {
+            "repo_id": COMET_REPO_ID,
+            "revision": COMET_REVISION,
+            "resolved_revision": model_dir.name,
+            "encoder_repo_id": COMET_ENCODER_REPO_ID,
+            "encoder_revision": COMET_ENCODER_REVISION,
+            "encoder_resolved_revision": encoder_dir.name,
+            "packages": {
+                name: _package_version(name)
+                for name in (
+                    "unbabel-comet",
+                    "torch",
+                    "transformers",
+                    "pytorch-lightning",
+                    "torchmetrics",
+                    "sentencepiece",
+                    "huggingface-hub",
+                )
+            },
+            "batch_size": comet_batch_size,
+            "device": "cuda" if torch.cuda.is_available() else "cpu",
+        }
+
+    for result in scored:
+        _, bleu, chrf = _sacrebleu_metrics()
+        result["metrics"] = {
+            "scored_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "source_sha256": sha256_file(Path(__file__)),
+            "primary": "macro mean of per-sample chrF++ against all available references",
+            "secondary": "first-reference corpus chrF++ and BLEU; optional reference-based COMET",
+            "versions": versions,
+            "comet": comet_metadata,
+            "summary": _summaries(result["samples"], bleu, chrf),
+        }
+    return scored
+
+
+_WORKLOAD_FIELDS = (
+    "input_contract",
+    "cache_policy",
+    "sample_order",
+    "tracks",
+    "games",
+    "text_types",
+    "repeats",
+    "warmups",
+    "seed",
+    "limit",
+    "device_preference",
+)
+
+
+def _validate_comparison_contract(baseline: dict[str, Any], candidate: dict[str, Any]) -> None:
+    for label, result in (("Baseline", baseline), ("Candidate", candidate)):
+        if result.get("schema_version") != 1:
+            raise BenchmarkError(f"{label} report does not use schema version 1")
+        if not isinstance(result.get("samples"), list) or not result["samples"]:
+            raise BenchmarkError(f"{label} report has no samples")
+        configuration = result.get("configuration")
+        if not isinstance(configuration, dict):
+            raise BenchmarkError(f"{label} report has no workload configuration")
+        missing = [field for field in _WORKLOAD_FIELDS if field not in configuration]
+        if missing:
+            raise BenchmarkError(f"{label} workload is missing: {', '.join(missing)}")
+
+    checks = {
+        "corpus lock": (baseline["corpus"].get("lock_sha256"), candidate["corpus"].get("lock_sha256")),
+        "selected corpus identity": (
+            baseline["corpus"].get("selected_identity_sha256"),
+            candidate["corpus"].get("selected_identity_sha256"),
+        ),
+        "source registry": (
+            baseline["corpus"].get("source_registry_sha256"),
+            candidate["corpus"].get("source_registry_sha256"),
+        ),
+        "reference reviews": (
+            baseline["corpus"].get("reviews_sha256"),
+            candidate["corpus"].get("reviews_sha256"),
+        ),
+        "model registry": (
+            baseline["model_registry"].get("sha256"),
+            candidate["model_registry"].get("sha256"),
+        ),
+        "production translation source": (
+            baseline["application"].get("translate_source_sha256"),
+            candidate["application"].get("translate_source_sha256"),
+        ),
+        "production worker source": (
+            baseline["application"].get("worker_source_sha256"),
+            candidate["application"].get("worker_source_sha256"),
+        ),
+        "benchmark runner sources": (
+            fingerprint(baseline.get("benchmark_sources")),
+            fingerprint(candidate.get("benchmark_sources")),
+        ),
+        "workload": (fingerprint(baseline["configuration"]), fingerprint(candidate["configuration"])),
+    }
+    changed = [name for name, (first, second) in checks.items() if not first or first != second]
+    if changed:
+        raise BenchmarkError(f"Cannot compare reports with different {', '.join(changed)}")
+
+    identity_fields = (
+        "id",
+        "pair_id",
+        "source_id",
+        "game",
+        "platform",
+        "release_year",
+        "genre",
+        "text_type",
+        "length_bucket",
+        "track",
+        "source",
+        "references",
+        "reference_status",
+        "independently_verified",
+        "provenance",
+    )
+    baseline_records = [{field: sample.get(field) for field in identity_fields} for sample in baseline["samples"]]
+    candidate_records = [{field: sample.get(field) for field in identity_fields} for sample in candidate["samples"]]
+    if baseline_records != candidate_records:
+        raise BenchmarkError("Cannot compare reports whose ordered sample records differ")
+
+
+def _outcome(paired: dict[str, Any]) -> str:
+    delta = paired["delta"]
+    lower, upper = paired["ci95"]
+    if delta is None or lower is None or upper is None:
+        return "inconclusive"
+    if lower > 0:
+        return "candidate_better"
+    if upper < 0:
+        return "candidate_worse"
+    if lower == upper == 0:
+        return "tied"
+    return "inconclusive"
+
+
+def _score_map(samples: list[dict[str, Any]], metric: str, *, track: str = "screen") -> dict[str, float]:
+    return {
+        sample["id"]: float(sample["metrics"][metric])
+        for sample in samples
+        if sample["track"] == track and metric in sample["metrics"]
+    }
+
+
+def _wins(baseline: dict[str, float], candidate: dict[str, float]) -> dict[str, int]:
+    wins = losses = ties = 0
+    for sample_id in baseline.keys() & candidate.keys():
+        difference = candidate[sample_id] - baseline[sample_id]
+        if difference > 1e-12:
+            wins += 1
+        elif difference < -1e-12:
+            losses += 1
+        else:
+            ties += 1
+    return {"candidate_wins": wins, "candidate_losses": losses, "ties": ties}
+
+
+def _blind_review_summary(review: dict[str, Any] | None, baseline_id: str, candidate_id: str) -> dict[str, Any]:
+    if review is None:
+        return {
+            "judgments": 0,
+            "candidate_wins": 0,
+            "baseline_wins": 0,
+            "ties": 0,
+            "candidate_win_rate": None,
+            "candidate_win_rate_ci95": [None, None],
+        }
+    if review.get("schema_version") != 1:
+        raise BenchmarkError("Blind review report does not use schema version 1")
+    models = review.get("models")
+    if set(models or []) != {baseline_id, candidate_id}:
+        raise BenchmarkError("Blind review report was created for different models")
+    return {
+        key: review.get(key)
+        for key in (
+            "judgments",
+            "candidate_wins",
+            "baseline_wins",
+            "ties",
+            "candidate_win_rate",
+            "candidate_win_rate_ci95",
+        )
+    }
+
+
+def compare_results(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    bootstrap_iterations: int = 10_000,
+    bootstrap_seed: int = 1729,
+    min_verified_pairs: int = 100,
+    min_games: int = 5,
+    min_blind_judgments: int = 100,
+    max_p95_ms: float = 750.0,
+    max_latency_ratio: float = 10.0,
+    max_artifact_gib: float = 5.0,
+    max_artifact_ratio: float = 4.0,
+    max_game_regression: float = 2.0,
+    blind_review: dict[str, Any] | None = None,
+    private_holdout_passed: bool = False,
+    license_approved: bool = False,
+) -> dict[str, Any]:
+    _validate_comparison_contract(baseline, candidate)
+    baseline, candidate = score_results([baseline, candidate], include_comet=False)
+
+    baseline_screen = _score_map(baseline["samples"], "chrfpp")
+    candidate_screen = _score_map(candidate["samples"], "chrfpp")
+    paired = bootstrap_mean_delta(
+        baseline_screen,
+        candidate_screen,
+        iterations=bootstrap_iterations,
+        seed=bootstrap_seed,
+    )
+    outcome = _outcome(paired)
+    wins = _wins(baseline_screen, candidate_screen)
+
+    paired_comet = None
+    baseline_comet = _score_map(baseline["samples"], "comet")
+    candidate_comet = _score_map(candidate["samples"], "comet")
+    if baseline_comet and baseline_comet.keys() == candidate_comet.keys():
+        paired_comet = bootstrap_mean_delta(
+            baseline_comet,
+            candidate_comet,
+            iterations=bootstrap_iterations,
+            seed=bootstrap_seed,
+        )
+
+    baseline_summary = baseline["metrics"]["summary"]
+    candidate_summary = candidate["metrics"]["summary"]
+    baseline_primary = baseline_summary["by"]["track"]["screen"]
+    candidate_primary = candidate_summary["by"]["track"]["screen"]
+
+    baseline_p95 = baseline_primary["latency_ms"]["p95"]
+    candidate_p95 = candidate_primary["latency_ms"]["p95"]
+    latency_ratio = candidate_p95 / baseline_p95 if baseline_p95 and candidate_p95 is not None else None
+    baseline_bytes = baseline["model"]["artifacts"]["bytes"]
+    candidate_bytes = candidate["model"]["artifacts"]["bytes"]
+    artifact_ratio = candidate_bytes / baseline_bytes if baseline_bytes else None
+
+    by_game = {}
+    regressed_games = []
+    games = sorted({sample["game"] for sample in baseline["samples"] if sample["track"] == "screen"})
+    for game in games:
+        first = {
+            sample["id"]: sample["metrics"]["chrfpp"]
+            for sample in baseline["samples"]
+            if sample["track"] == "screen" and sample["game"] == game
+        }
+        second = {
+            sample["id"]: sample["metrics"]["chrfpp"]
+            for sample in candidate["samples"]
+            if sample["track"] == "screen" and sample["game"] == game
+        }
+        game_paired = bootstrap_mean_delta(first, second, iterations=bootstrap_iterations, seed=bootstrap_seed)
+        by_game[game] = game_paired
+        if game_paired["delta"] is not None and game_paired["delta"] < -max_game_regression:
+            regressed_games.append(game)
+
+    verified = [
+        sample for sample in baseline["samples"] if sample["track"] == "screen" and sample["independently_verified"]
+    ]
+    verified_games = {sample["game"] for sample in verified}
+    review_summary = _blind_review_summary(blind_review, baseline["model_id"], candidate["model_id"])
+
+    blockers = []
+    if outcome != "candidate_better":
+        blockers.append(f"paired screen-track chrF++ outcome is {outcome}, not candidate_better")
+    if candidate_primary["errors"]:
+        blockers.append(f"candidate had {candidate_primary['errors']} screen-track sample errors")
+    if candidate_primary["empty_predictions"]:
+        blockers.append(f"candidate returned {candidate_primary['empty_predictions']} empty screen translations")
+    if candidate_primary["nondeterministic_samples"]:
+        blockers.append(
+            f"candidate produced multiple outputs for {candidate_primary['nondeterministic_samples']} screen samples"
+        )
+    leakage_tolerance = max(1, round(candidate_primary["samples"] * 0.01))
+    if candidate_primary["japanese_leakage"] > baseline_primary["japanese_leakage"] + leakage_tolerance:
+        blockers.append("candidate Japanese-text leakage regressed by more than one percentage point")
+    baseline_numbers = baseline_primary["number_preservation"]["rate"]
+    candidate_numbers = candidate_primary["number_preservation"]["rate"]
+    if baseline_numbers is not None and (candidate_numbers is None or candidate_numbers < baseline_numbers - 0.02):
+        blockers.append("candidate numeric-token preservation regressed by more than two percentage points")
+    if candidate_p95 is None or candidate_p95 > max_p95_ms:
+        blockers.append(f"candidate screen p95 latency must be at most {max_p95_ms:.0f} ms")
+    if latency_ratio is None or latency_ratio > max_latency_ratio:
+        blockers.append(f"candidate screen p95 latency exceeds {max_latency_ratio:.1f}x baseline")
+    if candidate_bytes > max_artifact_gib * 1024**3:
+        blockers.append(f"candidate artifacts exceed {max_artifact_gib:.1f} GiB")
+    if artifact_ratio is None or artifact_ratio > max_artifact_ratio:
+        blockers.append(f"candidate artifacts exceed {max_artifact_ratio:.1f}x baseline size")
+    if regressed_games:
+        blockers.append(
+            f"candidate regressed by more than {max_game_regression:.1f} chrF++ on: {', '.join(regressed_games)}"
+        )
+    if len(verified) < min_verified_pairs:
+        blockers.append(f"only {len(verified)} independently verified pairs; require {min_verified_pairs}")
+    if len(verified_games) < min_games:
+        blockers.append(f"verified references cover {len(verified_games)} games; require {min_games}")
+    if review_summary["judgments"] is None or review_summary["judgments"] < min_blind_judgments:
+        blockers.append(
+            f"only {review_summary['judgments'] or 0} blind human preference judgments; require {min_blind_judgments}"
+        )
+    elif (
+        not review_summary["candidate_win_rate_ci95"]
+        or review_summary["candidate_win_rate_ci95"][0] is None
+        or review_summary["candidate_win_rate_ci95"][0] <= 0.5
+    ):
+        blockers.append("blind human preference lower confidence bound does not exceed 50%")
+    if not private_holdout_passed:
+        blockers.append("no separately held private game-text evaluation has been recorded")
+    if not license_approved:
+        blockers.append(f"deployment license has not been approved: {candidate['model']['registry']['license']}")
+
+    return {
+        "schema_version": 1,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "baseline": {"model_id": baseline["model_id"], "label": baseline["label"]},
+        "candidate": {"model_id": candidate["model_id"], "label": candidate["label"]},
+        "primary_metric": "screen-track macro sentence chrF++ (higher is better)",
+        "paired_chrfpp": paired,
+        "paired_comet": paired_comet,
+        "statistical_outcome": outcome,
+        **wins,
+        "baseline_summary": baseline_summary,
+        "candidate_summary": candidate_summary,
+        "latency_p95_ratio": latency_ratio,
+        "artifact_size_ratio": artifact_ratio,
+        "by_game": by_game,
+        "blind_review": review_summary,
+        "promotion_gate": {
+            "ready": not blockers,
+            "blockers": blockers,
+            "verified_pairs": len(verified),
+            "verified_games": len(verified_games),
+            "requirements": {
+                "min_verified_pairs": min_verified_pairs,
+                "min_games": min_games,
+                "min_blind_judgments": min_blind_judgments,
+                "max_p95_ms": max_p95_ms,
+                "max_latency_ratio": max_latency_ratio,
+                "max_artifact_gib": max_artifact_gib,
+                "max_artifact_ratio": max_artifact_ratio,
+                "max_game_regression": max_game_regression,
+                "private_holdout_passed": private_holdout_passed,
+                "license_approved": license_approved,
+            },
+        },
+    }
+
+
+def format_scored_summary(result: dict[str, Any]) -> str:
+    overall = result["metrics"]["summary"]["overall"]
+    screen = result["metrics"]["summary"]["by"]["track"]["screen"]
+    return (
+        f"chrF++={screen['macro_sentence_chrfpp']:.2f} screen / "
+        f"{overall['macro_sentence_chrfpp']:.2f} all, BLEU={screen['corpus_bleu']:.2f}, "
+        f"p95={screen['latency_ms']['p95']:.1f} ms, errors={screen['errors']}"
+    )

--- a/benchmark/translation/models.json
+++ b/benchmark/translation/models.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "models": {
+    "production": {
+      "label": "Interpreter production Sugoi V4",
+      "adapter": "production",
+      "repo_id": "entai2965/sugoi-v4-ja-en-ctranslate2",
+      "revision": "71d67eb8e73ec2f5aaefc0689e03a4eb843d3a2b",
+      "license": "Model repository does not declare a standard license; review required",
+      "deployment_status": "license_review_required",
+      "packages": [],
+      "generation": {
+        "beam_size": 5,
+        "max_decoding_length": 256
+      }
+    },
+    "quickmt": {
+      "label": "QuickMT Japanese-English 200M",
+      "adapter": "quickmt",
+      "repo_id": "quickmt/quickmt-ja-en",
+      "revision": "e9ae594ff322d95254d730867c6166b25fd2c704",
+      "license": "CC-BY-4.0",
+      "deployment_status": "attribution_required",
+      "packages": [
+        "ctranslate2==4.6.2",
+        "sentencepiece==0.2.1",
+        "huggingface-hub==1.2.3",
+        "nvidia-cublas-cu12==12.9.1.4",
+        "nvidia-cudnn-cu12==9.17.1.4"
+      ],
+      "generation": {
+        "beam_size": 5,
+        "max_decoding_length": 256
+      }
+    },
+    "lfm2-350m": {
+      "label": "LFM2 350M EN-JP MT",
+      "adapter": "lfm2",
+      "repo_id": "LiquidAI/LFM2-350M-ENJP-MT",
+      "revision": "80367784d525777ad7565b24534ba5810eeac59f",
+      "license": "LFM Open License v1.0",
+      "deployment_status": "license_review_required",
+      "packages": [
+        "torch==2.9.1",
+        "transformers==4.57.6",
+        "sentencepiece==0.2.1",
+        "huggingface-hub==0.36.0",
+        "hf-xet==1.6.0"
+      ],
+      "uv_indexes": ["https://download.pytorch.org/whl/cu128"],
+      "generation": {
+        "do_sample": true,
+        "max_new_tokens": 256,
+        "temperature": 0.5,
+        "top_p": 1.0,
+        "min_p": 0.1,
+        "repetition_penalty": 1.05
+      }
+    },
+    "hy-mt-1.8b": {
+      "label": "Tencent HY-MT 1.5 1.8B",
+      "adapter": "hy_mt",
+      "repo_id": "tencent/HY-MT1.5-1.8B",
+      "revision": "dbad03788f49709801014c95d481a514c272ca52",
+      "license": "Tencent Hunyuan Community License",
+      "deployment_status": "license_review_required",
+      "packages": [
+        "torch==2.9.1",
+        "transformers==4.57.6",
+        "sentencepiece==0.2.1",
+        "huggingface-hub==0.36.0",
+        "hf-xet==1.6.0"
+      ],
+      "uv_indexes": ["https://download.pytorch.org/whl/cu128"],
+      "generation": {
+        "do_sample": true,
+        "max_new_tokens": 256,
+        "temperature": 0.7,
+        "top_k": 20,
+        "top_p": 0.6,
+        "repetition_penalty": 1.05
+      }
+    },
+    "riva-4b-v2": {
+      "label": "NVIDIA Riva Translate 4B v2",
+      "adapter": "riva",
+      "repo_id": "nvidia/Riva-Translate-4B-Instruct-v2",
+      "revision": "040d958b128018ff0bed2542a7b51005e9ea563c",
+      "license": "NVIDIA Open Model License; Apache-2.0 additional information",
+      "deployment_status": "license_review_required",
+      "packages": [
+        "torch==2.9.1",
+        "transformers==4.57.6",
+        "sentencepiece==0.2.1",
+        "huggingface-hub==0.36.0",
+        "hf-xet==1.6.0"
+      ],
+      "uv_indexes": ["https://download.pytorch.org/whl/cu128"],
+      "generation": {
+        "do_sample": false,
+        "max_new_tokens": 256
+      }
+    },
+    "translategemma-4b": {
+      "label": "Google TranslateGemma 4B",
+      "adapter": "translategemma",
+      "repo_id": "google/translategemma-4b-it",
+      "revision": "10042cb0e6e7fdce748996a71dc3dc432a4e0c89",
+      "license": "Gemma Terms of Use; Hugging Face access approval required",
+      "deployment_status": "license_review_required",
+      "gated": true,
+      "packages": [
+        "torch==2.9.1",
+        "transformers==4.57.6",
+        "sentencepiece==0.2.1",
+        "huggingface-hub==0.36.0",
+        "hf-xet==1.6.0"
+      ],
+      "uv_indexes": ["https://download.pytorch.org/whl/cu128"],
+      "generation": {
+        "do_sample": false,
+        "max_new_tokens": 256
+      }
+    }
+  }
+}

--- a/benchmark/translation/review.py
+++ b/benchmark/translation/review.py
@@ -1,0 +1,230 @@
+"""Generate and score model-blind human translation review packets."""
+
+from __future__ import annotations
+
+import csv
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+from benchlib import BenchmarkError, fingerprint, stable_rank, write_json
+
+IMMUTABLE_FIELDS = (
+    "review_id",
+    "sample_id",
+    "game",
+    "platform",
+    "track",
+    "text_type",
+    "length_bucket",
+    "source",
+    "translation_a",
+    "translation_b",
+)
+REVIEW_FIELDS = (*IMMUTABLE_FIELDS, "preference", "severity", "notes")
+
+
+def _paired_samples(baseline: dict[str, Any], candidate: dict[str, Any], track: str) -> list[tuple[Any, Any]]:
+    first = {sample["id"]: sample for sample in baseline.get("samples", []) if sample["track"] == track}
+    second = {sample["id"]: sample for sample in candidate.get("samples", []) if sample["track"] == track}
+    if first.keys() != second.keys():
+        raise BenchmarkError("Blind review inputs do not contain identical selected samples")
+    for sample_id in first:
+        identity = (first[sample_id]["source"], first[sample_id]["references"])
+        if identity != (second[sample_id]["source"], second[sample_id]["references"]):
+            raise BenchmarkError(f"Blind review source/reference mismatch for {sample_id}")
+    return [(first[sample_id], second[sample_id]) for sample_id in sorted(first)]
+
+
+def create_blind_packet(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    *,
+    packet_path: Path,
+    key_path: Path,
+    track: str = "screen",
+    limit: int | None = None,
+    seed: int = 1729,
+) -> dict[str, Any]:
+    if baseline.get("model_id") == candidate.get("model_id"):
+        raise BenchmarkError("Blind review requires two different model IDs")
+    pairs = _paired_samples(baseline, candidate, track)
+    if limit is not None:
+        if limit < 1:
+            raise BenchmarkError("Blind review limit must be at least 1")
+        pairs = sorted(
+            pairs,
+            key=lambda pair: (stable_rank(f"blind-packet-{seed}", pair[0]["id"]), pair[0]["id"]),
+        )[:limit]
+        pairs.sort(key=lambda pair: pair[0]["id"])
+
+    rows = []
+    assignments = {}
+    baseline_id = baseline["model_id"]
+    candidate_id = candidate["model_id"]
+    for index, (first, second) in enumerate(pairs, start=1):
+        review_id = f"R{index:04d}"
+        swap = int(stable_rank(f"blind-side-{seed}", first["id"])[-1], 16) % 2 == 1
+        if swap:
+            translation_a, translation_b = second["prediction"], first["prediction"]
+            model_a, model_b = candidate_id, baseline_id
+        else:
+            translation_a, translation_b = first["prediction"], second["prediction"]
+            model_a, model_b = baseline_id, candidate_id
+        row = {
+            "review_id": review_id,
+            "sample_id": first["id"],
+            "game": first["game"],
+            "platform": first["platform"],
+            "track": first["track"],
+            "text_type": first["text_type"],
+            "length_bucket": first["length_bucket"],
+            "source": first["source"],
+            "translation_a": translation_a,
+            "translation_b": translation_b,
+            "preference": "",
+            "severity": "",
+            "notes": "",
+        }
+        rows.append(row)
+        assignments[review_id] = {"sample_id": first["id"], "model_a": model_a, "model_b": model_b}
+
+    packet_path.parent.mkdir(parents=True, exist_ok=True)
+    with packet_path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=REVIEW_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    immutable = [{field: row[field] for field in IMMUTABLE_FIELDS} for row in rows]
+    key = {
+        "schema_version": 1,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "models": [baseline_id, candidate_id],
+        "baseline_model_id": baseline_id,
+        "candidate_model_id": candidate_id,
+        "track": track,
+        "seed": seed,
+        "packet_fingerprint": fingerprint(immutable),
+        "assignments": assignments,
+    }
+    write_json(key_path, key)
+    return {"rows": len(rows), "packet": str(packet_path), "key": str(key_path)}
+
+
+def _wilson_interval(wins: int, total: int) -> list[float | None]:
+    if not total:
+        return [None, None]
+    z = 1.959963984540054
+    probability = wins / total
+    denominator = 1 + z * z / total
+    center = (probability + z * z / (2 * total)) / denominator
+    margin = z * math.sqrt(probability * (1 - probability) / total + z * z / (4 * total * total)) / denominator
+    return [center - margin, center + margin]
+
+
+def score_blind_packet(packet_path: Path, key: dict[str, Any]) -> dict[str, Any]:
+    try:
+        with packet_path.open(encoding="utf-8-sig", newline="") as handle:
+            rows = list(csv.DictReader(handle))
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"Blind review packet not found: {packet_path}") from exc
+    if not rows or tuple(rows[0]) != REVIEW_FIELDS:
+        raise BenchmarkError("Blind review CSV columns changed or packet is empty")
+    immutable = [{field: row[field] for field in IMMUTABLE_FIELDS} for row in rows]
+    if fingerprint(immutable) != key.get("packet_fingerprint"):
+        raise BenchmarkError("Blind review packet source text or translations changed after randomization")
+    assignments = key.get("assignments", {})
+    if {row["review_id"] for row in rows} != set(assignments):
+        raise BenchmarkError("Blind review packet rows do not match its separate key")
+
+    baseline_id = key["baseline_model_id"]
+    candidate_id = key["candidate_model_id"]
+    counts = {baseline_id: 0, candidate_id: 0, "tie": 0, "invalid": 0}
+    judgments = 0
+    for row in rows:
+        preference = row["preference"].strip().upper()
+        if not preference:
+            continue
+        if preference not in {"A", "B", "TIE", "INVALID"}:
+            raise BenchmarkError(
+                f"{row['review_id']} preference must be A, B, TIE, INVALID, or blank; got {preference!r}"
+            )
+        judgments += 1
+        if preference in {"A", "B"}:
+            model_id = assignments[row["review_id"]][f"model_{preference.lower()}"]
+            counts[model_id] += 1
+        elif preference == "TIE":
+            counts["tie"] += 1
+        else:
+            counts["invalid"] += 1
+
+    candidate_wins = counts[candidate_id]
+    baseline_wins = counts[baseline_id]
+    decisive = candidate_wins + baseline_wins
+    return {
+        "schema_version": 1,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "models": [baseline_id, candidate_id],
+        "packet_fingerprint": key["packet_fingerprint"],
+        "judgments": judgments,
+        "decisive_judgments": decisive,
+        "candidate_wins": candidate_wins,
+        "baseline_wins": baseline_wins,
+        "ties": counts["tie"],
+        "invalid": counts["invalid"],
+        "candidate_win_rate": candidate_wins / decisive if decisive else None,
+        "candidate_win_rate_ci95": _wilson_interval(candidate_wins, decisive),
+    }
+
+
+def create_reference_packet(
+    lock: dict[str, Any],
+    *,
+    packet_path: Path,
+    limit: int | None = None,
+    seed: int = 1729,
+) -> int:
+    pairs = list(lock["pairs"])
+    if limit is not None:
+        if limit < 1:
+            raise BenchmarkError("Reference review limit must be at least 1")
+        pairs = sorted(
+            pairs,
+            key=lambda pair: (stable_rank(f"reference-packet-{seed}", pair["pair_id"]), pair["pair_id"]),
+        )[:limit]
+    fields = (
+        "pair_id",
+        "game",
+        "platform",
+        "text_type",
+        "length_bucket",
+        "screen_source",
+        "normalized_source",
+        "reference_1",
+        "reference_2",
+        "decision",
+        "corrected_reference",
+        "notes",
+    )
+    packet_path.parent.mkdir(parents=True, exist_ok=True)
+    with packet_path.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for pair in sorted(pairs, key=lambda item: item["pair_id"]):
+            writer.writerow(
+                {
+                    "pair_id": pair["pair_id"],
+                    "game": pair["game"],
+                    "platform": pair["platform"],
+                    "text_type": pair["text_type"],
+                    "length_bucket": pair["length_bucket"],
+                    "screen_source": pair["screen"],
+                    "normalized_source": pair.get("normalized") or "",
+                    "reference_1": pair["references"][0],
+                    "reference_2": pair["references"][1] if len(pair["references"]) > 1 else "",
+                    "decision": "",
+                    "corrected_reference": "",
+                    "notes": "",
+                }
+            )
+    return len(pairs)

--- a/benchmark/translation/review.py
+++ b/benchmark/translation/review.py
@@ -23,6 +23,21 @@ IMMUTABLE_FIELDS = (
     "translation_b",
 )
 REVIEW_FIELDS = (*IMMUTABLE_FIELDS, "preference", "severity", "notes")
+SPREADSHEET_FORMULA_PREFIXES = ("=", "+", "-", "@")
+
+
+def _spreadsheet_safe_cell(value: Any) -> Any:
+    """Encode a CSV cell as text without changing its canonical in-memory value."""
+    if not isinstance(value, str) or not value:
+        return value
+    stripped = value.lstrip(" \t\r\n")
+    if value.startswith(("'", "\t", "\r", "\n")) or stripped.startswith(SPREADSHEET_FORMULA_PREFIXES):
+        return f"'{value}"
+    return value
+
+
+def _spreadsheet_safe_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {field: _spreadsheet_safe_cell(value) for field, value in row.items()}
 
 
 def _paired_samples(baseline: dict[str, Any], candidate: dict[str, Any], track: str) -> list[tuple[Any, Any]]:
@@ -91,13 +106,15 @@ def create_blind_packet(
         assignments[review_id] = {"sample_id": first["id"], "model_a": model_a, "model_b": model_b}
 
     packet_path.parent.mkdir(parents=True, exist_ok=True)
+    exported_rows = [_spreadsheet_safe_row(row) for row in rows]
     with packet_path.open("w", encoding="utf-8-sig", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=REVIEW_FIELDS)
         writer.writeheader()
-        writer.writerows(rows)
+        writer.writerows(exported_rows)
     immutable = [{field: row[field] for field in IMMUTABLE_FIELDS} for row in rows]
+    exported_immutable = [{field: row[field] for field in IMMUTABLE_FIELDS} for row in exported_rows]
     key = {
-        "schema_version": 1,
+        "schema_version": 2,
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "models": [baseline_id, candidate_id],
         "baseline_model_id": baseline_id,
@@ -105,6 +122,7 @@ def create_blind_packet(
         "track": track,
         "seed": seed,
         "packet_fingerprint": fingerprint(immutable),
+        "export_fingerprint": fingerprint(exported_immutable),
         "assignments": assignments,
     }
     write_json(key_path, key)
@@ -131,7 +149,7 @@ def score_blind_packet(packet_path: Path, key: dict[str, Any]) -> dict[str, Any]
     if not rows or tuple(rows[0]) != REVIEW_FIELDS:
         raise BenchmarkError("Blind review CSV columns changed or packet is empty")
     immutable = [{field: row[field] for field in IMMUTABLE_FIELDS} for row in rows]
-    if fingerprint(immutable) != key.get("packet_fingerprint"):
+    if fingerprint(immutable) != key.get("export_fingerprint"):
         raise BenchmarkError("Blind review packet source text or translations changed after randomization")
     assignments = key.get("assignments", {})
     if {row["review_id"] for row in rows} != set(assignments):
@@ -212,19 +230,21 @@ def create_reference_packet(
         writer.writeheader()
         for pair in sorted(pairs, key=lambda item: item["pair_id"]):
             writer.writerow(
-                {
-                    "pair_id": pair["pair_id"],
-                    "game": pair["game"],
-                    "platform": pair["platform"],
-                    "text_type": pair["text_type"],
-                    "length_bucket": pair["length_bucket"],
-                    "screen_source": pair["screen"],
-                    "normalized_source": pair.get("normalized") or "",
-                    "reference_1": pair["references"][0],
-                    "reference_2": pair["references"][1] if len(pair["references"]) > 1 else "",
-                    "decision": "",
-                    "corrected_reference": "",
-                    "notes": "",
-                }
+                _spreadsheet_safe_row(
+                    {
+                        "pair_id": pair["pair_id"],
+                        "game": pair["game"],
+                        "platform": pair["platform"],
+                        "text_type": pair["text_type"],
+                        "length_bucket": pair["length_bucket"],
+                        "screen_source": pair["screen"],
+                        "normalized_source": pair.get("normalized") or "",
+                        "reference_1": pair["references"][0],
+                        "reference_2": pair["references"][1] if len(pair["references"]) > 1 else "",
+                        "decision": "",
+                        "corrected_reference": "",
+                        "notes": "",
+                    }
+                )
             )
     return len(pairs)

--- a/benchmark/translation/reviews.json
+++ b/benchmark/translation/reviews.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "reviews": {}
+}

--- a/benchmark/translation/runner.py
+++ b/benchmark/translation/runner.py
@@ -1,0 +1,287 @@
+"""Execute pinned translation models against an identical frozen workload."""
+
+from __future__ import annotations
+
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from adapters import create_adapter, environment_package_versions
+from benchlib import (
+    BenchmarkError,
+    fingerprint,
+    has_japanese,
+    latency_summary,
+    modal_prediction,
+    number_preservation,
+    percentile,
+    select_samples,
+    sha256_file,
+    stable_rank,
+)
+
+
+def _git_metadata(repo_root: Path) -> dict[str, Any]:
+    def command(*args: str) -> str | None:
+        try:
+            return subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL).strip()
+        except (OSError, subprocess.CalledProcessError):
+            return None
+
+    dirty = command("status", "--porcelain", "--untracked-files=no")
+    translate_path = repo_root / "src" / "interpreter" / "translate.py"
+    worker_path = repo_root / "src" / "interpreter" / "gui" / "workers.py"
+    return {
+        "commit": command("rev-parse", "HEAD"),
+        "branch": command("branch", "--show-current"),
+        "tracked_files_dirty": bool(dirty),
+        "translate_source_sha256": sha256_file(translate_path),
+        "worker_source_sha256": sha256_file(worker_path),
+    }
+
+
+def _benchmark_source_metadata(benchmark_dir: Path) -> dict[str, str]:
+    names = ("adapters.py", "benchlib.py", "corpus.py", "runner.py")
+    return {name: sha256_file(benchmark_dir / name) for name in names}
+
+
+def _selected_identity(samples: list[dict[str, Any]]) -> str:
+    fields = (
+        "id",
+        "pair_id",
+        "source_id",
+        "game",
+        "platform",
+        "release_year",
+        "genre",
+        "text_type",
+        "length_bucket",
+        "track",
+        "source",
+        "references",
+        "reference_status",
+        "independently_verified",
+        "provenance",
+    )
+    return fingerprint([{field: sample[field] for field in fields} for sample in samples])
+
+
+def _limit_samples(samples: list[dict[str, Any]], limit: int | None, seed: int) -> list[dict[str, Any]]:
+    if limit is None:
+        return samples
+    if limit < 1:
+        raise BenchmarkError("limit must be at least 1")
+    ranked = sorted(samples, key=lambda item: (stable_rank(f"smoke-{seed}", item["id"]), item["id"]))
+    chosen = {sample["id"] for sample in ranked[:limit]}
+    return [sample for sample in samples if sample["id"] in chosen]
+
+
+def summarize_runtime(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    numeric_preserved = numeric_total = 0
+    length_ratios = []
+    for sample in samples:
+        preserved, total = number_preservation(sample["source"], sample.get("prediction", ""))
+        numeric_preserved += preserved
+        numeric_total += total
+        source_length = len(sample["source"].replace(" ", ""))
+        if source_length:
+            length_ratios.append(len(sample.get("prediction", "")) / source_length)
+    return {
+        "samples": len(samples),
+        "errors": sum(bool(sample.get("errors")) for sample in samples),
+        "empty_predictions": sum(not sample.get("prediction", "").strip() for sample in samples),
+        "japanese_leakage": sum(has_japanese(sample.get("prediction")) for sample in samples),
+        "nondeterministic_samples": sum(sample.get("unique_predictions", 0) > 1 for sample in samples),
+        "number_preservation": {
+            "preserved": numeric_preserved,
+            "total": numeric_total,
+            "rate": numeric_preserved / numeric_total if numeric_total else None,
+        },
+        "output_source_length_ratio_median": statistics.median(length_ratios) if length_ratios else None,
+        "latency_ms": latency_summary(samples),
+    }
+
+
+def _summaries(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    dimensions = {}
+    for field in ("track", "game", "platform", "text_type", "length_bucket"):
+        dimensions[field] = {
+            value: summarize_runtime([sample for sample in samples if sample[field] == value])
+            for value in sorted({sample[field] for sample in samples})
+        }
+    return {"overall": summarize_runtime(samples), "by": dimensions}
+
+
+def run_benchmark(
+    *,
+    lock: dict[str, Any],
+    lock_path: Path,
+    model_registry: dict[str, Any],
+    model_registry_path: Path,
+    model_id: str,
+    repo_root: Path,
+    label: str | None,
+    tracks: list[str] | None,
+    games: list[str] | None,
+    text_types: list[str] | None,
+    repeats: int,
+    warmups: int,
+    seed: int,
+    limit: int | None,
+    device: str,
+) -> dict[str, Any]:
+    if repeats < 1:
+        raise BenchmarkError("repeats must be at least 1")
+    if warmups < 0:
+        raise BenchmarkError("warmups cannot be negative")
+    models = model_registry.get("models", {})
+    if model_id not in models:
+        raise BenchmarkError(f"Unknown model ID {model_id}; choose from {', '.join(sorted(models))}")
+
+    selected = select_samples(lock, tracks=tracks, games=games, text_types=text_types)
+    selected = _limit_samples(selected, limit, seed)
+    if not selected:
+        raise BenchmarkError("No corpus samples matched the requested filters")
+
+    model = models[model_id]
+    adapter = create_adapter(model_id, model, repo_root, device, seed)
+    print(f"loading {model['label']} ({model['repo_id']}@{model['revision']})", flush=True)
+    load_started = time.perf_counter()
+    adapter.load()
+    adapter.synchronize()
+    load_ms = (time.perf_counter() - load_started) * 1000
+    print(f"loaded on {adapter.device} in {load_ms:.1f} ms", flush=True)
+
+    if warmups:
+        warmup_sample = selected[0]
+        for _ in range(warmups):
+            adapter.clear_cache()
+            adapter.translate(warmup_sample["source"])
+            adapter.synchronize()
+
+    accumulators = {sample["id"]: {"predictions": [], "latencies_ms": [], "errors": []} for sample in selected}
+    rng = random.Random(seed)
+    for repeat in range(repeats):
+        order = list(selected)
+        rng.shuffle(order)
+        print(f"repeat {repeat + 1}/{repeats}", flush=True)
+        for index, sample in enumerate(order, start=1):
+            accumulator = accumulators[sample["id"]]
+            adapter.clear_cache()
+            adapter.synchronize()
+            started = time.perf_counter()
+            try:
+                prediction = adapter.translate(sample["source"])
+                adapter.synchronize()
+                elapsed_ms = (time.perf_counter() - started) * 1000
+                accumulator["predictions"].append(prediction)
+                accumulator["latencies_ms"].append(elapsed_ms)
+            except Exception as exc:  # Keep failed cases paired and auditable.
+                try:
+                    adapter.synchronize()
+                except Exception:
+                    pass
+                elapsed_ms = (time.perf_counter() - started) * 1000
+                if "out of memory" in str(exc).casefold():
+                    raise BenchmarkError(f"{model_id} exhausted memory on {sample['id']}: {exc}") from exc
+                accumulator["latencies_ms"].append(elapsed_ms)
+                accumulator["errors"].append(f"{type(exc).__name__}: {exc}")
+            if index == 1 or index % 25 == 0 or index == len(order):
+                print(
+                    f"  [{index:03d}/{len(order):03d}] {sample['id']} {accumulator['latencies_ms'][-1]:.1f} ms",
+                    flush=True,
+                )
+
+    results = []
+    for sample in selected:
+        accumulator = accumulators[sample["id"]]
+        predictions = accumulator["predictions"]
+        variants = Counter(predictions)
+        result = {
+            key: sample[key]
+            for key in (
+                "id",
+                "pair_id",
+                "source_id",
+                "game",
+                "platform",
+                "release_year",
+                "genre",
+                "text_type",
+                "length_bucket",
+                "track",
+                "source",
+                "references",
+                "reference_status",
+                "independently_verified",
+                "provenance",
+            )
+        }
+        result.update(
+            {
+                "prediction": modal_prediction(predictions),
+                "prediction_variants": dict(variants),
+                "unique_predictions": len(variants),
+                "latencies_ms": accumulator["latencies_ms"],
+                "latency_median_ms": percentile(accumulator["latencies_ms"], 0.5),
+                "errors": accumulator["errors"],
+            }
+        )
+        results.append(result)
+
+    benchmark_dir = Path(__file__).resolve().parent
+    workload = {
+        "input_contract": "one exact player-visible Japanese text unit per translation call",
+        "cache_policy": "clear application translation cache before every measured call",
+        "sample_order": "same deterministic shuffled order for every model and repeat",
+        "tracks": sorted(tracks or []),
+        "games": sorted(games or []),
+        "text_types": sorted(text_types or []),
+        "repeats": repeats,
+        "warmups": warmups,
+        "seed": seed,
+        "limit": limit,
+        "device_preference": device,
+    }
+    return {
+        "schema_version": 1,
+        "label": label or model["label"],
+        "model_id": model_id,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "configuration": workload,
+        "corpus": {
+            "lock": str(lock_path.resolve()),
+            "lock_sha256": fingerprint(lock),
+            "source_registry_sha256": lock["source_registry_sha256"],
+            "reviews_sha256": lock["reviews_sha256"],
+            "selected_identity_sha256": _selected_identity(selected),
+            "selected_samples": len(selected),
+        },
+        "model_registry": {
+            "path": str(model_registry_path.resolve()),
+            "sha256": fingerprint(model_registry),
+        },
+        "application": _git_metadata(repo_root),
+        "benchmark_sources": _benchmark_source_metadata(benchmark_dir),
+        "environment": {
+            "python": sys.version,
+            "executable": sys.executable,
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "packages": environment_package_versions(model),
+            "hf_home": os.environ.get("HF_HOME"),
+            "hf_hub_offline": os.environ.get("HF_HUB_OFFLINE"),
+        },
+        "model": adapter.metadata(),
+        "model_load_ms": load_ms,
+        "summary": _summaries(results),
+        "samples": results,
+    }

--- a/benchmark/translation/runner.py
+++ b/benchmark/translation/runner.py
@@ -48,7 +48,7 @@ def _git_metadata(repo_root: Path) -> dict[str, Any]:
 
 
 def _benchmark_source_metadata(benchmark_dir: Path) -> dict[str, str]:
-    names = ("adapters.py", "benchlib.py", "corpus.py", "runner.py")
+    names = ("adapters.py", "benchlib.py", "benchmark.py", "corpus.py", "runner.py")
     return {name: sha256_file(benchmark_dir / name) for name in names}
 
 

--- a/benchmark/translation/sources.json
+++ b/benchmark/translation/sources.json
@@ -1,0 +1,236 @@
+{
+  "schema_version": 1,
+  "corpus_id": "retro-ja-en-v1",
+  "sampling_seed": "interpreter-translation-benchmark-v1",
+  "maximum_source_characters": 160,
+  "length_buckets": {
+    "short": [1, 15],
+    "medium": [16, 45],
+    "long": [46, 160]
+  },
+  "sources": [
+    {
+      "id": "famicom-detective-club-girl",
+      "game": "Famicom Detective Club: The Girl Who Stands Behind",
+      "platform": "Famicom Disk System",
+      "release_year": 1989,
+      "genre": "adventure",
+      "parser": "nintendo_fixed",
+      "repository": "https://github.com/sudgy/nintendo_translations",
+      "commit": "39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "provenance_url": "https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "license": "MIT (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "girl_messages.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/girl_messages.txt",
+          "sha256": "ec3facb64eee1a67f1a3dcd23f94f8ff712849395a4290750b47396ced00edd5"
+        },
+        "options": {
+          "path": "girl_options.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/girl_options.txt",
+          "sha256": "6c9aeea50e8d11e1a68b9ee0deb491958a1965ee6f1cc70a2cff2e8e9d9f656d"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 8, "long": 8},
+        "menu": {"short": 8, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "famicom-detective-club-heir",
+      "game": "Famicom Detective Club: The Missing Heir",
+      "platform": "Famicom Disk System",
+      "release_year": 1988,
+      "genre": "adventure",
+      "parser": "nintendo_fixed",
+      "repository": "https://github.com/sudgy/nintendo_translations",
+      "commit": "39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "provenance_url": "https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "license": "MIT (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "heir_messages.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/heir_messages.txt",
+          "sha256": "d42c7e45d39300d2a0bb6299249e63a5db47abadc3ba9be7b67d57f468d1fe9e"
+        },
+        "options": {
+          "path": "heir_options.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/heir_options.txt",
+          "sha256": "6dea1e7d4cc9bb1f22cef6c1752cdd9750c800ceecec310894106af78630d899"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 8, "long": 8},
+        "menu": {"short": 8, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "shin-onigashima",
+      "game": "Famicom Mukashibanashi: Shin Onigashima",
+      "platform": "Famicom Disk System",
+      "release_year": 1987,
+      "genre": "adventure",
+      "parser": "nintendo_variable",
+      "repository": "https://github.com/sudgy/nintendo_translations",
+      "commit": "39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "provenance_url": "https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "license": "MIT (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "onigashima_messages.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/onigashima_messages.txt",
+          "sha256": "b7027a6519e0f13d6bad2eab1ecc5f9be2d8e7fcfbe4cb70cf604d34be78c266"
+        },
+        "options": {
+          "path": "onigashima_options.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/onigashima_options.txt",
+          "sha256": "b1bd75481f367de72b8974c2a2e8f66c54fa3181243a937397e4a511a2c28abb"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 8, "long": 8},
+        "menu": {"short": 8, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "time-twist",
+      "game": "Time Twist: Rekishi no Katasumi de",
+      "platform": "Famicom Disk System",
+      "release_year": 1991,
+      "genre": "adventure",
+      "parser": "nintendo_variable",
+      "repository": "https://github.com/sudgy/nintendo_translations",
+      "commit": "39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "provenance_url": "https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "license": "MIT (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "time_twist_messages.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/time_twist_messages.txt",
+          "sha256": "ea97c9cd14c9fa95bc55ef2321d88797a5c3e67799248dca3ab1c9879c8f34ab"
+        },
+        "options": {
+          "path": "time_twist_options.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/time_twist_options.txt",
+          "sha256": "5e069b676d1808f316e02a40c9a06c1544a3f1056ae91302603224f5538a6bb0"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 8, "long": 8},
+        "menu": {"short": 8, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "yuyuki",
+      "game": "Famicom Mukashibanashi: Yūyūki",
+      "platform": "Famicom Disk System",
+      "release_year": 1989,
+      "genre": "adventure",
+      "parser": "nintendo_variable",
+      "repository": "https://github.com/sudgy/nintendo_translations",
+      "commit": "39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "provenance_url": "https://github.com/sudgy/nintendo_translations/tree/39f7fb43549ebc428f6216c27cbd81ed738ba3c2",
+      "license": "MIT (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "yuyuki_messages.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/yuyuki_messages.txt",
+          "sha256": "67f480056d65826bf772c72b00882d0b1e5b34846d7b6e7a5c53c7b4297956ca"
+        },
+        "options": {
+          "path": "yuyuki_options.txt",
+          "url": "https://raw.githubusercontent.com/sudgy/nintendo_translations/39f7fb43549ebc428f6216c27cbd81ed738ba3c2/yuyuki_options.txt",
+          "sha256": "8a732adb656c16c53751e30b8e9fa63720620d3ea04c66307037c74cbeec6c3a"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 8, "long": 8},
+        "menu": {"short": 8, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "phantasy-star",
+      "game": "Phantasy Star",
+      "platform": "Sega Master System",
+      "release_year": 1987,
+      "genre": "role-playing game",
+      "parser": "phantasy_star",
+      "repository": "https://github.com/maxim-zhao/psrp",
+      "commit": "2a327b7163eb7864c004ac2f46a00e66a88d2e1d",
+      "provenance_url": "https://github.com/maxim-zhao/psrp/tree/2a327b7163eb7864c004ac2f46a00e66a88d2e1d",
+      "license": "Evaluation only; repository states translated files may not be sold commercially without authorization",
+      "reference_status": "source_review_with_alternate",
+      "files": {
+        "messages": {
+          "path": "script.yaml",
+          "url": "https://raw.githubusercontent.com/maxim-zhao/psrp/2a327b7163eb7864c004ac2f46a00e66a88d2e1d/psrp/script.yaml",
+          "sha256": "0ea02e0db83a292b640dbaffd1aa4127673de74baca93736625dd26322ed8382"
+        },
+        "options": {
+          "path": "menus.yaml",
+          "url": "https://raw.githubusercontent.com/maxim-zhao/psrp/2a327b7163eb7864c004ac2f46a00e66a88d2e1d/psrp/menus.yaml",
+          "sha256": "58152552d482e59e1db194f16d5004a84cf123a2febd904b1171b42b589cb57d"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 10, "long": 8},
+        "menu": {"short": 6, "medium": 2, "long": 1}
+      }
+    },
+    {
+      "id": "metal-slader-glory",
+      "game": "Metal Slader Glory: Director's Cut",
+      "platform": "Super Famicom",
+      "release_year": 2000,
+      "genre": "adventure",
+      "parser": "metal_slader",
+      "repository": "https://github.com/romh-acking/metal-slader-glory-sfc-en",
+      "commit": "beb3e86dec0fd928ac165eaa7b9bfe29358b03ea",
+      "provenance_url": "https://github.com/romh-acking/metal-slader-glory-sfc-en/tree/beb3e86dec0fd928ac165eaa7b9bfe29358b03ea",
+      "license": "GPL-3.0 (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "messages": {
+          "path": "Script.json",
+          "url": "https://raw.githubusercontent.com/romh-acking/metal-slader-glory-sfc-en/beb3e86dec0fd928ac165eaa7b9bfe29358b03ea/script/Script.json",
+          "sha256": "d6ee490372397e1d2e893b3911915f0fb9595e1ee12fa384aa4e0c568fb37ed4"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 6, "medium": 10, "long": 8},
+        "menu": {"short": 11, "medium": 0, "long": 0}
+      }
+    },
+    {
+      "id": "dragon-slayer-legend-of-heroes",
+      "game": "Dragon Slayer: The Legend of Heroes",
+      "platform": "NEC PC-9801",
+      "release_year": 1989,
+      "genre": "role-playing game",
+      "parser": "ds6_pc98",
+      "repository": "https://github.com/nleseul/ds6_pc98_trans",
+      "commit": "2d32f8f93afa50dbe8003521624194a91a6f86a9",
+      "provenance_url": "https://github.com/nleseul/ds6_pc98_trans/tree/2d32f8f93afa50dbe8003521624194a91a6f86a9",
+      "license": "Unlicense (repository); original game text remains third-party game content",
+      "reference_status": "single_source_review",
+      "files": {
+        "archive": {
+          "path": "ds6_pc98_trans.zip",
+          "url": "https://codeload.github.com/nleseul/ds6_pc98_trans/zip/2d32f8f93afa50dbe8003521624194a91a6f86a9",
+          "sha256": "6c8ec3e10428470f4bc6cf98f11c198add6c2edc5172cdc4eed8f2ae13862136"
+        }
+      },
+      "quotas": {
+        "dialogue": {"short": 8, "medium": 12, "long": 10},
+        "menu": {"short": 10, "medium": 0, "long": 0},
+        "system": {"short": 4, "medium": 4, "long": 2}
+      }
+    }
+  ]
+}

--- a/tests/test_translation_benchmark.py
+++ b/tests/test_translation_benchmark.py
@@ -1,0 +1,277 @@
+"""Tests for the standalone translation benchmark tooling."""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_DIR = ROOT / "benchmark" / "translation"
+sys.path.insert(0, str(BENCHMARK_DIR))
+
+# The standalone OCR benchmark deliberately has modules with the same names.
+# Import this toolset as one temporary group, then restore any module that the
+# OCR tests loaded during collection so both suites can share a pytest process.
+_previous_benchlib = sys.modules.pop("benchlib", None)
+try:
+    import adapters
+    import benchlib
+    import corpus
+    import metrics
+    import review
+finally:
+    if _previous_benchlib is None:
+        sys.modules.pop("benchlib", None)
+    else:
+        sys.modules["benchlib"] = _previous_benchlib
+
+
+def _load(name: str) -> dict:
+    return json.loads((BENCHMARK_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_registries_are_valid_and_models_are_revision_pinned():
+    sources = _load("sources.json")
+    models = _load("models.json")
+    reviews = _load("reviews.json")
+
+    assert benchlib.validate_source_registry(sources) == []
+    assert benchlib.validate_model_registry(models) == []
+    assert benchlib.validate_reviews(reviews) == []
+    assert all(len(model["revision"]) == 40 for model in models["models"].values())
+    assert (
+        sum(
+            quota
+            for source in sources["sources"]
+            for by_length in source["quotas"].values()
+            for quota in by_length.values()
+        )
+        == 268
+    )
+
+
+def test_corpus_cleaning_removes_controls_but_preserves_visible_punctuation():
+    raw = r"\LineWidthPortraitShowing/(CODE 21 Elina:) えっ(LINE)本当[！？]{82}(End quote)(STOP)"
+    assert corpus._clean_metal(raw) == "えっ 本当！？"
+    assert corpus._clean_phantasy("<line>アリサ<wait><player>") == ""
+
+    screen_raw = "<X1e>セリオス<X04>こんにちは。<RETN>"
+    reference_raw = "<X1e>Selios<X04>Hello.<RETN>"
+    screen = corpus._clean_ds6(screen_raw)
+    reference = corpus._clean_ds6(reference_raw)
+    assert screen == "セリオス こんにちは。"
+    assert reference == "Selios Hello."
+    assert corpus._valid_ds6_record(screen_raw, reference_raw, screen, reference)
+    assert not corpus._valid_ds6_record(
+        "スライムさんが現れた。このファイルは Ｍ−０３６ です。<RETN>",
+        "Slimey appears. This file is M-036.<RETN>",
+        "スライムさんが現れた。このファイルは Ｍ−０３６ です。",
+        "Slimey appears. This file is M-036.",
+    )
+    assert not corpus._valid_ds6_record(
+        "<CALL123>は話した。",
+        "<CALL123> spoke.",
+        "は話した。",
+        "spoke.",
+    )
+    assert not corpus._valid_ds6_record(
+        "は 奇妙な かおりの花粉をふりまいた。<X0a>",
+        " scatters its odd-smelling pollen.<X0a>",
+        "は 奇妙な かおりの花粉をふりまいた。",
+        "scatters its odd-smelling pollen.",
+    )
+
+
+def test_sampling_is_deterministic_and_stratified():
+    registry = {
+        "sampling_seed": "fixed",
+        "sources": [
+            {
+                "id": "game",
+                "quotas": {
+                    "dialogue": {"short": 2, "medium": 0, "long": 0},
+                },
+            }
+        ],
+    }
+    entries = [
+        {
+            "pair_id": f"game:{index}",
+            "source_id": "game",
+            "text_type": "dialogue",
+            "length_bucket": "short",
+        }
+        for index in range(10)
+    ]
+    first = benchlib.select_entries(entries, registry)
+    second = benchlib.select_entries(list(reversed(entries)), registry)
+    assert [item["pair_id"] for item in first] == [item["pair_id"] for item in second]
+    assert len(first) == 2
+
+
+def test_only_blind_human_reference_reviews_count_as_verified():
+    entry = {
+        "pair_id": "game:1",
+        "reference_status": "single_source_review",
+    }
+    reviews = {
+        "reviews": {
+            "game:1": {
+                "status": "verified",
+                "reviewer_kind": "human",
+                "blind_to_model_outputs": True,
+            }
+        }
+    }
+    assert benchlib.apply_reviews([entry], reviews)[0]["independently_verified"] is True
+    reviews["reviews"]["game:1"]["blind_to_model_outputs"] = False
+    assert benchlib.apply_reviews([entry], reviews)[0]["independently_verified"] is False
+
+
+def test_candidate_output_normalization_matches_production_contract():
+    value = "  ‘one’ “two” – — −\u00a0…  "
+    assert adapters.normalize_display_output(value) == "'one' \"two\" - -- - ..."
+
+
+class _FakeMetric:
+    def sentence_score(self, prediction, references):
+        del references
+        return SimpleNamespace(score={"baseline": 20.0, "candidate": 40.0}.get(prediction, 0.0))
+
+    def corpus_score(self, predictions, references):
+        del references
+        values = [{"baseline": 20.0, "candidate": 40.0}.get(value, 0.0) for value in predictions]
+        return SimpleNamespace(score=sum(values) / len(values))
+
+    def get_signature(self):
+        return "fake-signature"
+
+
+def _result(model_id: str, prediction: str) -> dict:
+    sample = {
+        "id": "game:1::screen",
+        "pair_id": "game:1",
+        "source_id": "game",
+        "game": "Game",
+        "platform": "Console",
+        "release_year": 1990,
+        "genre": "role-playing game",
+        "text_type": "dialogue",
+        "length_bucket": "short",
+        "track": "screen",
+        "source": "こんにちは",
+        "references": ["Hello"],
+        "reference_status": "single_source_review",
+        "independently_verified": False,
+        "provenance": {"repository": "https://example.invalid"},
+        "prediction": prediction,
+        "prediction_variants": {prediction: 3},
+        "unique_predictions": 1,
+        "latencies_ms": [10.0, 11.0, 12.0],
+        "latency_median_ms": 11.0,
+        "errors": [],
+    }
+    configuration = {
+        "input_contract": "unit",
+        "cache_policy": "clear",
+        "sample_order": "fixed",
+        "tracks": [],
+        "games": [],
+        "text_types": [],
+        "repeats": 3,
+        "warmups": 2,
+        "seed": 1729,
+        "limit": None,
+        "device_preference": "auto",
+    }
+    return {
+        "schema_version": 1,
+        "label": model_id,
+        "model_id": model_id,
+        "configuration": configuration,
+        "corpus": {
+            "lock_sha256": "lock",
+            "selected_identity_sha256": "identity",
+            "source_registry_sha256": "sources",
+            "reviews_sha256": "reviews",
+        },
+        "model_registry": {"sha256": "models"},
+        "application": {"translate_source_sha256": "translate", "worker_source_sha256": "worker"},
+        "benchmark_sources": {"runner.py": "runner"},
+        "model": {
+            "registry": {"license": "review required"},
+            "artifacts": {"bytes": 1_000_000},
+        },
+        "samples": [sample],
+    }
+
+
+@pytest.fixture
+def fake_sacrebleu(monkeypatch):
+    monkeypatch.setattr(
+        metrics,
+        "_sacrebleu_metrics",
+        lambda: (SimpleNamespace(__version__="test"), _FakeMetric(), _FakeMetric()),
+    )
+
+
+def test_comparison_is_paired_and_promotion_stays_blocked_without_human_gates(fake_sacrebleu):
+    comparison = metrics.compare_results(
+        _result("production", "baseline"),
+        _result("candidate-model", "candidate"),
+        bootstrap_iterations=100,
+    )
+    assert comparison["statistical_outcome"] == "candidate_better"
+    assert comparison["paired_chrfpp"]["delta"] == 20.0
+    assert comparison["promotion_gate"]["ready"] is False
+    blockers = " ".join(comparison["promotion_gate"]["blockers"])
+    assert "independently verified" in blockers
+    assert "blind human" in blockers
+    assert "private" in blockers
+    assert "license" in blockers
+
+
+def test_comparison_rejects_changed_source_even_when_ids_match(fake_sacrebleu):
+    baseline = _result("production", "baseline")
+    candidate = _result("candidate-model", "candidate")
+    candidate["samples"][0]["source"] = "さようなら"
+    with pytest.raises(benchlib.BenchmarkError, match="sample records differ"):
+        metrics.compare_results(baseline, candidate, bootstrap_iterations=10)
+
+
+def test_blind_packet_uses_separate_key_and_detects_mutation(tmp_path):
+    baseline = _result("production", "baseline")
+    candidate = _result("candidate-model", "candidate")
+    packet = tmp_path / "packet.csv"
+    key_path = tmp_path / "key.json"
+    report = review.create_blind_packet(
+        baseline,
+        candidate,
+        packet_path=packet,
+        key_path=key_path,
+    )
+    assert report["rows"] == 1
+    key = json.loads(key_path.read_text(encoding="utf-8"))
+    with packet.open(encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    assert "production" not in rows[0]["translation_a"] + rows[0]["translation_b"]
+    rows[0]["preference"] = "A"
+    with packet.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=review.REVIEW_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    scored = review.score_blind_packet(packet, key)
+    assert scored["judgments"] == 1
+
+    rows[0]["source"] = "changed"
+    with packet.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=review.REVIEW_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    with pytest.raises(benchlib.BenchmarkError, match="changed after randomization"):
+        review.score_blind_packet(packet, key)

--- a/tests/test_translation_benchmark.py
+++ b/tests/test_translation_benchmark.py
@@ -59,6 +59,9 @@ def test_corpus_cleaning_removes_controls_but_preserves_visible_punctuation():
     raw = r"\LineWidthPortraitShowing/(CODE 21 Elina:) えっ(LINE)本当[！？]{82}(End quote)(STOP)"
     assert corpus._clean_metal(raw) == "えっ 本当！？"
     assert corpus._clean_phantasy("<line>アリサ<wait><player>") == ""
+    assert corpus._clean_nintendo("悪事がある｜ 契約まで") == "悪事がある 契約まで"
+    assert benchlib.has_japanese("・・・「!?」") is False
+    assert benchlib.has_japanese("忠！！") is True
 
     screen_raw = "<X1e>セリオス<X04>こんにちは。<RETN>"
     reference_raw = "<X1e>Selios<X04>Hello.<RETN>"
@@ -241,6 +244,16 @@ def test_comparison_rejects_changed_source_even_when_ids_match(fake_sacrebleu):
     candidate = _result("candidate-model", "candidate")
     candidate["samples"][0]["source"] = "さようなら"
     with pytest.raises(benchlib.BenchmarkError, match="sample records differ"):
+        metrics.compare_results(baseline, candidate, bootstrap_iterations=10)
+
+
+def test_comparison_rejects_mismatched_comet_configuration(fake_sacrebleu):
+    baseline = _result("production", "baseline")
+    candidate = _result("candidate-model", "candidate")
+    for result, revision in ((baseline, "first"), (candidate, "second")):
+        result["samples"][0]["metrics"] = {"comet": 0.5}
+        result["metrics"] = {"comet": {"revision": revision}}
+    with pytest.raises(benchlib.BenchmarkError, match="different COMET configurations"):
         metrics.compare_results(baseline, candidate, bootstrap_iterations=10)
 
 

--- a/tests/test_translation_benchmark.py
+++ b/tests/test_translation_benchmark.py
@@ -288,3 +288,64 @@ def test_blind_packet_uses_separate_key_and_detects_mutation(tmp_path):
         writer.writerows(rows)
     with pytest.raises(benchlib.BenchmarkError, match="changed after randomization"):
         review.score_blind_packet(packet, key)
+
+
+@pytest.mark.parametrize("prefix", ["=", "+", "-", "@"])
+def test_blind_packet_escapes_formula_cells_without_changing_integrity(tmp_path, prefix):
+    baseline = _result("production", f"{prefix}baseline")
+    candidate = _result("candidate-model", f"{prefix}candidate")
+    baseline["samples"][0]["source"] = f"{prefix}source"
+    candidate["samples"][0]["source"] = f"{prefix}source"
+    packet = tmp_path / "packet.csv"
+    key_path = tmp_path / "key.json"
+
+    review.create_blind_packet(baseline, candidate, packet_path=packet, key_path=key_path)
+    key = json.loads(key_path.read_text(encoding="utf-8"))
+    with packet.open(encoding="utf-8-sig", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows[0]["source"] == f"'{prefix}source"
+    assert rows[0]["translation_a"].startswith(f"'{prefix}")
+    assert rows[0]["translation_b"].startswith(f"'{prefix}")
+    assert key["packet_fingerprint"] != key["export_fingerprint"]
+    rows[0]["preference"] = "A"
+    with packet.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=review.REVIEW_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    assert review.score_blind_packet(packet, key)["judgments"] == 1
+
+    rows[0]["source"] = f"''{prefix}source"
+    with packet.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=review.REVIEW_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+    with pytest.raises(benchlib.BenchmarkError, match="changed after randomization"):
+        review.score_blind_packet(packet, key)
+
+
+def test_reference_packet_escapes_all_formula_prefixes(tmp_path):
+    lock = {
+        "pairs": [
+            {
+                "pair_id": "game:1",
+                "game": "Game",
+                "platform": "Console",
+                "text_type": "dialogue",
+                "length_bucket": "short",
+                "screen": "=source",
+                "normalized": "+normalized",
+                "references": ["-reference", "@reference"],
+            }
+        ]
+    }
+    packet = tmp_path / "references.csv"
+
+    assert review.create_reference_packet(lock, packet_path=packet) == 1
+    with packet.open(encoding="utf-8-sig", newline="") as handle:
+        row = next(csv.DictReader(handle))
+
+    assert row["screen_source"] == "'=source"
+    assert row["normalized_source"] == "'+normalized"
+    assert row["reference_1"] == "'-reference"
+    assert row["reference_2"] == "'@reference"


### PR DESCRIPTION
## Summary

- add a reproducible Japanese-to-English benchmark that calls the exact production translation path
- freeze 268 real retro-game text pairs across eight FDS, SMS, SFC, and PC-98 titles from four commit-pinned fan-translation projects
- compare production Sugoi V4 with QuickMT, LFM2, HY-MT, and NVIDIA Riva in isolated revision/package-pinned environments
- add chrF++/BLEU/COMET scoring, paired bootstrap intervals, reliability/latency/size gates, and separate-key blind human review tooling
- keep corpus downloads, caches, review packets, and raw predictions out of Git while committing their hashes and a reproducible results summary

## Result

No production model is changed. None of the candidates proved better on the primary 268-pair screen-text track.

| Model | chrF++ | Delta vs production (95% CI) | Screen p95 | Outcome |
|---|---:|---:|---:|---|
| Production Sugoi V4 | 25.63 | — | 244.0 ms | baseline |
| QuickMT | 22.59 | -3.04 [-5.35, -0.73] | 97.7 ms | worse |
| LFM2 350M | 23.33 | -2.30 [-4.62, +0.00] | 1,426.1 ms | inconclusive |
| HY-MT 1.8B | 27.38 | +1.75 [-0.90, +4.44] | 4,000.7 ms | inconclusive |
| Riva 4B v2 | 25.79 | +0.15 [-2.11, +2.33] | 3,005.4 ms | inconclusive |

COMET favors HY-MT and Riva, which makes them useful candidates for a future blind bilingual review, but the primary intervals cross zero and both regress on individual games. All candidates also remain blocked on independent reference review, a private holdout, blind human preference testing, and deployment-license review. TranslateGemma support is registered but was not run because its gated terms have not been accepted in this environment.

Full methodology and the exact run identity are in `benchmark/translation/README.md` and `benchmark/translation/RESULTS.md`.

## Validation

- `ruff format --check benchmark/translation tests/test_translation_benchmark.py`
- `ruff check benchmark/translation tests/test_translation_benchmark.py`
- `pytest -q` (28 passed)
- corpus prepare/validate: fingerprint `8b03090234f41ce82ee737030dd0590674bb005acc1dc74b650ef9aa810b8d31`
- production fuzzy-cache audit: 0 conflicting pairs at the application 0.90 threshold
- full CUDA matrix: 6,060 measured translations, 0 inference errors, 0 empty outputs, 0 nondeterministic samples
