### PR TITLE
Keep Windows overlay above focused topmost fullscreen games

### DIFF
--- a/src/interpreter/capture/__init__.py
+++ b/src/interpreter/capture/__init__.py
@@ -256,6 +256,11 @@ class WindowCapture:
         return self._window_id is not None
 
     @property
+    def window_id(self) -> int | None:
+        """Get the platform window handle of the target window, if known."""
+        return self._window_id
+
+    @property
     def bounds(self) -> dict | None:
         """Get the bounds of the target window."""
         return self._last_bounds

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -931,6 +931,12 @@ class MainWindow(QMainWindow):
         # Get bounds (None on Wayland, dict on X11/Windows/macOS)
         bounds = self._capture.bounds or {}
 
+        # Keep the overlay above the game even after the game takes focus
+        # (a focused topmost fullscreen window otherwise covers it)
+        if not self._paused:
+            overlay = self._inplace_overlay if self._mode == OverlayMode.INPLACE else self._banner_overlay
+            overlay.ensure_above(getattr(self._capture, "window_id", None))
+
         if frame is None:
             return
 

--- a/src/interpreter/overlay/base.py
+++ b/src/interpreter/overlay/base.py
@@ -220,6 +220,18 @@ class BannerOverlayBase(QWidget):
         # Apply final size
         self.setFixedSize(current_width, new_height)
 
+    def ensure_above(self, window_id: int | None) -> None:
+        """Keep the overlay stacked above the target window.
+
+        Some platforms let a focused fullscreen game climb above always-on-top
+        windows (e.g. games that make themselves topmost on Windows). Platform
+        subclasses override this to re-raise the overlay when that happens.
+
+        Args:
+            window_id: Platform window handle of the captured window, or None.
+        """
+        return None
+
     # Dragging support
     def mousePressEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:
@@ -411,6 +423,18 @@ class InplaceOverlayBase(QWidget):
     @property
     def font_size(self) -> int:
         return self._font_size
+
+    def ensure_above(self, window_id: int | None) -> None:
+        """Keep the overlay stacked above the target window.
+
+        Some platforms let a focused fullscreen game climb above always-on-top
+        windows (e.g. games that make themselves topmost on Windows). Platform
+        subclasses override this to re-raise the overlay when that happens.
+
+        Args:
+            window_id: Platform window handle of the captured window, or None.
+        """
+        return None
 
     def showEvent(self, event):
         """Handle show event - subclasses can override for platform-specific setup."""

--- a/src/interpreter/overlay/windows.py
+++ b/src/interpreter/overlay/windows.py
@@ -45,17 +45,25 @@ class _WindowsOverlayMixin:
         if not window_id or not self.isVisible():
             return
         try:
-            user32 = ctypes.windll.user32
+            user32 = ctypes.WinDLL("user32", use_last_error=True)
             user32.GetWindow.argtypes = [wintypes.HWND, wintypes.UINT]
             user32.GetWindow.restype = wintypes.HWND
+            user32.SetWindowPos.argtypes = [wintypes.HWND, wintypes.HWND, *([ctypes.c_int] * 4), wintypes.UINT]
+            user32.SetWindowPos.restype = wintypes.BOOL
             hwnd = int(self.winId())
             if not self._is_window_above(user32, hwnd, window_id):
                 return
             # HWND_TOP moves a topmost window to the top of the topmost band
-            user32.SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE)
-            logger.debug("re-raised overlay above target window", window_id=window_id)
+            if user32.SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE):
+                logger.debug("re-raised overlay above target window", window_id=window_id)
+            else:
+                logger.warning(
+                    "failed to re-raise overlay above target window",
+                    window_id=window_id,
+                    win32_error=ctypes.get_last_error(),
+                )
         except Exception as e:
-            logger.debug("failed to re-raise overlay", error=str(e))
+            logger.warning("failed to re-raise overlay", error=str(e))
 
     @staticmethod
     def _is_window_above(user32, hwnd: int, window_id: int) -> bool:

--- a/src/interpreter/overlay/windows.py
+++ b/src/interpreter/overlay/windows.py
@@ -7,22 +7,77 @@ On Windows:
 - Click-through requires Win32 API (WS_EX_TRANSPARENT, WS_EX_LAYERED)
 """
 
+import ctypes
+from ctypes import wintypes
+
 from PySide6.QtCore import QPoint
 from PySide6.QtWidgets import QApplication
 
+from .. import log
 from .base import BannerOverlayBase, InplaceOverlayBase
 
+logger = log.get_logger()
 
-class BannerOverlay(BannerOverlayBase):
-    """Windows banner overlay.
+# Win32 constants
+GW_HWNDPREV = 3
+HWND_TOP = 0
+SWP_NOSIZE = 0x0001
+SWP_NOMOVE = 0x0002
+SWP_NOACTIVATE = 0x0010
 
-    No platform-specific overrides needed - base class handles everything.
+# Upper bound on how far up the z-order we look for the target window.
+# Only topmost windows sit above the overlay, so this is normally a handful.
+MAX_ZORDER_WALK = 64
+
+
+class _WindowsOverlayMixin:
+    """Z-order maintenance shared by both Windows overlays.
+
+    Overlays are created with WS_EX_TOPMOST, but Windows keeps all topmost
+    windows in one band and moves whichever one was activated last to the
+    top of it. Games that make themselves topmost in fullscreen therefore
+    cover the overlay as soon as they receive focus, and nothing raises the
+    overlay again (issue #255). ensure_above() detects that and re-raises
+    the overlay without activating it.
     """
 
-    pass
+    def ensure_above(self, window_id: int | None) -> None:
+        if not window_id or not self.isVisible():
+            return
+        try:
+            user32 = ctypes.windll.user32
+            user32.GetWindow.argtypes = [wintypes.HWND, wintypes.UINT]
+            user32.GetWindow.restype = wintypes.HWND
+            hwnd = int(self.winId())
+            if not self._is_window_above(user32, hwnd, window_id):
+                return
+            # HWND_TOP moves a topmost window to the top of the topmost band
+            user32.SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE)
+            logger.debug("re-raised overlay above target window", window_id=window_id)
+        except Exception as e:
+            logger.debug("failed to re-raise overlay", error=str(e))
+
+    @staticmethod
+    def _is_window_above(user32, hwnd: int, window_id: int) -> bool:
+        """Return True if window_id sits above hwnd in the z-order."""
+        current = user32.GetWindow(hwnd, GW_HWNDPREV)
+        for _ in range(MAX_ZORDER_WALK):
+            if not current:
+                return False
+            if current == window_id:
+                return True
+            current = user32.GetWindow(current, GW_HWNDPREV)
+        return False
 
 
-class InplaceOverlay(InplaceOverlayBase):
+class BannerOverlay(_WindowsOverlayMixin, BannerOverlayBase):
+    """Windows banner overlay.
+
+    Only needs z-order maintenance - base class handles everything else.
+    """
+
+
+class InplaceOverlay(_WindowsOverlayMixin, InplaceOverlayBase):
     """Windows inplace overlay.
 
     Key differences from macOS:


### PR DESCRIPTION
## Summary

Fixes #255. In inplace mode the translation disappeared as soon as the fullscreen game was clicked, and only came back after clicking the Interpreter window again.

**Root cause:** the overlays are created as topmost windows, but Windows keeps every topmost window in one band and moves whichever was activated last to the top of that band. Games/emulators that make themselves topmost in fullscreen therefore climb above the overlay when they receive focus, and nothing ever raises the overlay again. Reproduced locally with a fake topmost borderless-fullscreen window and the real overlay classes; a non-topmost fullscreen window does not trigger it, which is why not every game shows the problem. The banner overlay has the same flaw.

**Fix:**
- `overlay/base.py`: no-op `ensure_above(window_id)` on both overlay bases (macOS/Linux unaffected).
- `overlay/windows.py`: `_WindowsOverlayMixin.ensure_above()` walks up the z-order from the overlay HWND and, only if the target window is found above it, calls `SetWindowPos(HWND_TOP, SWP_NOACTIVATE)` to put the overlay back on top of the topmost band without stealing focus. No-op otherwise, so it does not fight other always-on-top windows.
- `capture/__init__.py`: `window_id` property on `WindowCapture`.
- `gui/main_window.py`: the 500 ms capture tick calls `ensure_above` for the active overlay while not paused, so the overlay returns within half a second of the game taking focus.

**Not covered:** true exclusive-fullscreen DirectX, where no external window can render over the focused game. The "comes back when I click the app" symptom in the report matches the topmost borderless case handled here.

## Test plan

- [x] Scripted repro on Windows 11: topmost fullscreen window activated → overlay hidden; `ensure_above` → visible; repeated calls are no-ops; re-focusing the game → hidden → restored. Verified for both inplace and banner overlays.
- [x] `ruff check` clean on changed files; `pytest tests` passes (10 tests).
- [ ] Reporter confirms with their game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

