### PR TITLE
Self-repair incomplete Sugoi V4 cache instead of failing to load

### DIFF
--- a/src/interpreter/translate.py
+++ b/src/interpreter/translate.py
@@ -198,19 +198,22 @@ class Translator:
         # Get model path (downloads from HuggingFace if needed)
         self._model_path = _get_sugoi_model_path()
 
+        # Only RuntimeError (CTranslate2/SentencePiece rejecting the files) and
+        # FileNotFoundError indicate an incomplete cache. Other OSErrors such as
+        # PermissionError are local problems a re-download cannot fix, so they
+        # propagate unchanged.
         try:
             self._load_from_path()
-        except (RuntimeError, OSError) as e:
+        except (RuntimeError, FileNotFoundError) as e:
             # An interrupted download can leave a snapshot with model.bin but without
             # config.json or the vocabularies, which CTranslate2 reports as an opaque
             # JSON error. Re-sync the snapshot with the Hub (only missing files are
             # fetched) and retry once before giving up.
             logger.warning("translation model failed to load, repairing cache", error=str(e))
-            self._translator = None
             self._model_path = _download_sugoi_model()
             try:
                 self._load_from_path()
-            except (RuntimeError, OSError) as retry_error:
+            except (RuntimeError, FileNotFoundError) as retry_error:
                 raise ModelLoadError(
                     f"Translation model is corrupted ({retry_error}). Click 'Fix Models' to repair."
                 ) from retry_error
@@ -218,9 +221,13 @@ class Translator:
     def _load_from_path(self) -> None:
         """Load CTranslate2 model and tokenizer from self._model_path.
 
+        Instance state is only updated once both components loaded, so a failure
+        never leaves the translator half-initialized (load() would otherwise
+        return early on the next attempt).
+
         Raises:
             RuntimeError: If CTranslate2 or SentencePiece reject the model files.
-            OSError: If a model file is missing.
+            OSError: If a model file is missing or unreadable.
         """
         import ctranslate2
         import sentencepiece as spm
@@ -231,20 +238,20 @@ class Translator:
             cuda_types = ctranslate2.get_supported_compute_types("cuda")
             if cuda_types:
                 # Try to load with GPU
-                self._translator = ctranslate2.Translator(
+                translator = ctranslate2.Translator(
                     _get_short_path(self._model_path),
                     device="cuda",
                 )
                 # Test inference to verify CUDA actually works
                 # (loading may succeed but inference can fail if cuBLAS is missing)
-                self._translator.translate_batch([["テスト"]])
+                translator.translate_batch([["テスト"]])
                 device = "cuda"
         except Exception as e:
             # GPU failed (load or inference), will use CPU below
             logger.debug("CUDA failed, falling back to CPU", error=str(e))
 
         if device == "cpu":
-            self._translator = ctranslate2.Translator(
+            translator = ctranslate2.Translator(
                 _get_short_path(self._model_path),
                 device="cpu",
             )
@@ -253,7 +260,10 @@ class Translator:
         # Read model as bytes to avoid Unicode path issues on Windows
         # (SentencePiece's C++ layer may not handle non-ASCII paths correctly)
         tokenizer_path = self._model_path / "spm" / "spm.ja.nopretok.model"
-        self._tokenizer = spm.SentencePieceProcessor(model_proto=tokenizer_path.read_bytes())
+        tokenizer = spm.SentencePieceProcessor(model_proto=tokenizer_path.read_bytes())
+
+        self._translator = translator
+        self._tokenizer = tokenizer
 
         device_info = "GPU" if device == "cuda" else "CPU"
         logger.info("sugoi v4 ready", device=device_info)

--- a/src/interpreter/translate.py
+++ b/src/interpreter/translate.py
@@ -18,14 +18,14 @@ from .models import ModelLoadError
 
 logger = log.get_logger()
 
-# Official HuggingFace repository for Sugoi V4
+# Official HuggingFace repository for Sugoi V4, pinned to a specific commit so the
+# file layout we rely on (model.bin, config.json, vocabularies, spm/) cannot change
+# underneath us. Bump deliberately when upgrading the model.
 SUGOI_REPO_ID = "entai2965/sugoi-v4-ja-en-ctranslate2"
+SUGOI_REVISION = "71d67eb8e73ec2f5aaefc0689e03a4eb843d3a2b"
 
-# Required files that must exist for the model to work
-REQUIRED_MODEL_FILES = [
-    "model.bin",
-    "spm/spm.ja.nopretok.model",
-]
+# Attempts for the online download; snapshot_download resumes where it left off.
+DOWNLOAD_ATTEMPTS = 3
 
 # Translation cache defaults
 DEFAULT_CACHE_SIZE = 200  # Max cached translations
@@ -54,62 +54,55 @@ def _get_short_path(path: Path) -> str:
     return str(path)
 
 
-def _validate_model_files(model_path: Path) -> bool:
-    """Check if all required model files exist.
+def _download_sugoi_model() -> Path:
+    """Download the Sugoi V4 snapshot from HuggingFace, or complete a partial one.
 
-    Args:
-        model_path: Path to the model directory.
-
-    Returns:
-        True if all required files exist, False otherwise.
-    """
-    for file_path in REQUIRED_MODEL_FILES:
-        if not (model_path / file_path).exists():
-            logger.warning("missing model file", file=file_path)
-            return False
-    return True
-
-
-def _get_sugoi_model_path() -> Path:
-    """Get path to Sugoi V4 translation model, downloading if needed.
-
-    Downloads from official HuggingFace source on first use.
-    Model is cached in standard HuggingFace cache (~/.cache/huggingface/).
+    snapshot_download compares the local cache against the repository's file list
+    and only fetches what is missing, so this also repairs a cache left incomplete
+    by an interrupted download. Transient failures are retried; the download resumes.
 
     Returns:
         Path to the model directory.
 
     Raises:
-        ModelLoadError: If model files are missing or corrupted.
+        ModelLoadError: If the download keeps failing.
     """
-    # First try to load from cache (no network request)
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        try:
+            return Path(snapshot_download(repo_id=SUGOI_REPO_ID, revision=SUGOI_REVISION))
+        except Exception as e:
+            if attempt == DOWNLOAD_ATTEMPTS:
+                raise ModelLoadError(
+                    f"Translation model download failed: {e}. Check your connection and click 'Fix Models' to retry."
+                ) from e
+            logger.warning("model download failed, retrying", attempt=attempt, error=str(e))
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _get_sugoi_model_path() -> Path:
+    """Get path to the Sugoi V4 snapshot, downloading it on first use.
+
+    A cached snapshot is returned without any network access. Whether it is
+    complete is only known once CTranslate2 loads it (see Translator.load),
+    which avoids hardcoding the repository's file layout here.
+
+    Returns:
+        Path to the model directory.
+
+    Raises:
+        ModelLoadError: If the model cannot be downloaded.
+    """
     try:
-        model_path = snapshot_download(
-            repo_id=SUGOI_REPO_ID,
-            local_files_only=True,
-        )
-        model_path = Path(model_path)
-        # Validate that required files exist
-        if _validate_model_files(model_path):
-            return model_path
-        # Files missing - raise error (UI will show "Fix Models" button)
-        raise ModelLoadError(
-            "Translation model cache is corrupted. Click 'Fix Models' to repair."
+        return Path(
+            snapshot_download(
+                repo_id=SUGOI_REPO_ID,
+                revision=SUGOI_REVISION,
+                local_files_only=True,
+            )
         )
     except LocalEntryNotFoundError:
-        pass
-
-    # Not cached, download from HuggingFace
-    logger.info("downloading sugoi v4 model", size="~1.1GB")
-    model_path = Path(snapshot_download(repo_id=SUGOI_REPO_ID))
-
-    # Validate download completed successfully
-    if not _validate_model_files(model_path):
-        raise ModelLoadError(
-            "Translation model download incomplete. Click 'Fix Models' to retry."
-        )
-
-    return model_path
+        logger.info("downloading sugoi v4 model", size="~1.1GB")
+        return _download_sugoi_model()
 
 
 def text_similarity(a: str, b: str) -> float:
@@ -202,11 +195,35 @@ class Translator:
 
         logger.info("loading sugoi v4")
 
-        import ctranslate2
-        import sentencepiece as spm
-
         # Get model path (downloads from HuggingFace if needed)
         self._model_path = _get_sugoi_model_path()
+
+        try:
+            self._load_from_path()
+        except (RuntimeError, OSError) as e:
+            # An interrupted download can leave a snapshot with model.bin but without
+            # config.json or the vocabularies, which CTranslate2 reports as an opaque
+            # JSON error. Re-sync the snapshot with the Hub (only missing files are
+            # fetched) and retry once before giving up.
+            logger.warning("translation model failed to load, repairing cache", error=str(e))
+            self._translator = None
+            self._model_path = _download_sugoi_model()
+            try:
+                self._load_from_path()
+            except (RuntimeError, OSError) as retry_error:
+                raise ModelLoadError(
+                    f"Translation model is corrupted ({retry_error}). Click 'Fix Models' to repair."
+                ) from retry_error
+
+    def _load_from_path(self) -> None:
+        """Load CTranslate2 model and tokenizer from self._model_path.
+
+        Raises:
+            RuntimeError: If CTranslate2 or SentencePiece reject the model files.
+            OSError: If a model file is missing.
+        """
+        import ctranslate2
+        import sentencepiece as spm
 
         # Load CTranslate2 model with GPU if available, fallback to CPU
         device = "cpu"

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -106,3 +106,129 @@ class TestGetShortPath:
         assert len(result) > 0
         # The path should exist (since we used an existing path)
         assert Path(result).exists()
+
+
+def _fake_model_dir(tmp_path: Path) -> Path:
+    """Create a directory with just the tokenizer file Translator reads directly."""
+    spm_dir = tmp_path / "spm"
+    spm_dir.mkdir()
+    (spm_dir / "spm.ja.nopretok.model").write_bytes(b"fake")
+    return tmp_path
+
+
+class TestModelLoading:
+    """Tests for cache lookup, self-repair of partial caches, and download retries."""
+
+    def _load(self, model_dir: Path, ctranslate2_side_effects: list):
+        """Run Translator.load with mocked ctranslate2/sentencepiece/snapshot_download."""
+        from interpreter import translate
+
+        ct2 = MagicMock()
+        ct2.get_supported_compute_types.return_value = []  # force CPU path
+        ct2.Translator.side_effect = ctranslate2_side_effects
+        spm = MagicMock()
+
+        with (
+            patch.dict(sys.modules, {"ctranslate2": ct2, "sentencepiece": spm}),
+            patch.object(translate, "snapshot_download") as snapshot_download,
+        ):
+            snapshot_download.return_value = str(model_dir)
+            translator = translate.Translator()
+            translator.load()
+        return translator, snapshot_download, ct2
+
+    def test_cached_model_loads_without_network(self, tmp_path):
+        model_dir = _fake_model_dir(tmp_path)
+        translator, snapshot_download, _ = self._load(model_dir, [MagicMock()])
+
+        assert translator._translator is not None
+        assert snapshot_download.call_count == 1
+        assert snapshot_download.call_args.kwargs["local_files_only"] is True
+
+    def test_pinned_revision_is_used(self, tmp_path):
+        from interpreter.translate import SUGOI_REVISION
+
+        model_dir = _fake_model_dir(tmp_path)
+        _, snapshot_download, _ = self._load(model_dir, [MagicMock()])
+
+        assert snapshot_download.call_args.kwargs["revision"] == SUGOI_REVISION
+
+    def test_partial_cache_is_repaired_online(self, tmp_path):
+        """Issue #249: missing config.json makes CTranslate2 raise a JSON null error."""
+        model_dir = _fake_model_dir(tmp_path)
+        json_error = RuntimeError("[json.exception.type_error.302] type must be string, but is null")
+        translator, snapshot_download, ct2 = self._load(model_dir, [json_error, MagicMock()])
+
+        assert translator._translator is not None
+        assert ct2.Translator.call_count == 2
+        # First call is local-only, second is the online re-sync
+        assert snapshot_download.call_count == 2
+        assert snapshot_download.call_args_list[0].kwargs["local_files_only"] is True
+        assert "local_files_only" not in snapshot_download.call_args_list[1].kwargs
+
+    def test_unrepairable_cache_raises_model_load_error(self, tmp_path):
+        from interpreter.models import ModelLoadError
+
+        model_dir = _fake_model_dir(tmp_path)
+        with pytest.raises(ModelLoadError, match="Fix Models"):
+            self._load(model_dir, [RuntimeError("bad"), RuntimeError("still bad")])
+
+    def test_missing_tokenizer_triggers_repair(self, tmp_path):
+        """A missing spm file raises OSError, which must also trigger the re-sync."""
+        from interpreter import translate
+
+        ct2 = MagicMock()
+        ct2.get_supported_compute_types.return_value = []
+        spm = MagicMock()
+
+        def repair(*args, **kwargs):
+            if "local_files_only" not in kwargs:
+                _fake_model_dir(tmp_path)
+            return str(tmp_path)
+
+        with (
+            patch.dict(sys.modules, {"ctranslate2": ct2, "sentencepiece": spm}),
+            patch.object(translate, "snapshot_download", side_effect=repair) as snapshot_download,
+        ):
+            translate.Translator().load()
+
+        assert snapshot_download.call_count == 2
+
+
+class TestDownloadRetry:
+    """Tests for _download_sugoi_model retry behaviour."""
+
+    def test_transient_failure_is_retried(self, tmp_path):
+        from interpreter import translate
+
+        with patch.object(
+            translate,
+            "snapshot_download",
+            side_effect=[ConnectionError("Server disconnected"), str(tmp_path)],
+        ) as snapshot_download:
+            assert translate._download_sugoi_model() == tmp_path
+        assert snapshot_download.call_count == 2
+
+    def test_persistent_failure_raises_model_load_error(self):
+        from interpreter import translate
+        from interpreter.models import ModelLoadError
+
+        with (
+            patch.object(
+                translate, "snapshot_download", side_effect=ConnectionError("Server disconnected")
+            ) as snapshot_download,
+            pytest.raises(ModelLoadError, match="Fix Models"),
+        ):
+            translate._download_sugoi_model()
+        assert snapshot_download.call_count == translate.DOWNLOAD_ATTEMPTS
+
+    def test_uncached_model_is_downloaded(self, tmp_path):
+        from huggingface_hub.utils import LocalEntryNotFoundError
+
+        from interpreter import translate
+
+        with patch.object(
+            translate, "snapshot_download", side_effect=[LocalEntryNotFoundError("nope"), str(tmp_path)]
+        ) as snapshot_download:
+            assert translate._get_sugoi_model_path() == tmp_path
+        assert snapshot_download.call_count == 2

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -194,6 +194,55 @@ class TestModelLoading:
 
         assert snapshot_download.call_count == 2
 
+    def test_failed_retry_leaves_no_partial_state(self, tmp_path):
+        """Greptile P1: tokenizer failing after a repaired model load must not leave
+        _translator set, otherwise a later load() returns early without a tokenizer."""
+        from interpreter import translate
+        from interpreter.models import ModelLoadError
+
+        model_dir = _fake_model_dir(tmp_path)
+        ct2 = MagicMock()
+        ct2.get_supported_compute_types.return_value = []
+        ct2.Translator.side_effect = [RuntimeError("bad config"), MagicMock(), MagicMock()]
+        spm = MagicMock()
+        spm.SentencePieceProcessor.side_effect = [RuntimeError("bad proto"), MagicMock()]
+
+        with (
+            patch.dict(sys.modules, {"ctranslate2": ct2, "sentencepiece": spm}),
+            patch.object(translate, "snapshot_download", return_value=str(model_dir)),
+        ):
+            translator = translate.Translator()
+            with pytest.raises(ModelLoadError):
+                translator.load()
+            assert translator._translator is None
+            assert translator._tokenizer is None
+
+            # A later load() must actually retry, not return early
+            translator.load()
+            assert translator._translator is not None
+            assert translator._tokenizer is not None
+
+    def test_permission_error_is_not_treated_as_corruption(self, tmp_path):
+        """Greptile P2: an unreadable file is a local problem; do not start a download."""
+        from interpreter import translate
+
+        model_dir = _fake_model_dir(tmp_path)
+        ct2 = MagicMock()
+        ct2.get_supported_compute_types.return_value = []
+        ct2.Translator.side_effect = PermissionError("access denied")
+        spm = MagicMock()
+
+        with (
+            patch.dict(sys.modules, {"ctranslate2": ct2, "sentencepiece": spm}),
+            patch.object(translate, "snapshot_download", return_value=str(model_dir)) as snapshot_download,
+            pytest.raises(PermissionError, match="access denied"),
+        ):
+            translate.Translator().load()
+
+        # Only the local-only lookup happened, no online repair
+        assert snapshot_download.call_count == 1
+        assert snapshot_download.call_args.kwargs["local_files_only"] is True
+
 
 class TestDownloadRetry:
     """Tests for _download_sugoi_model retry behaviour."""


### PR DESCRIPTION
## Summary

Fixes #249. The reporter saw `[json.exception.type_error.302] type must be string, but is null` on every launch, and a mid-download disconnect when retrying via Fix Models.

**Root cause:** an interrupted HuggingFace download leaves a snapshot with `model.bin` but without `config.json` / the vocabularies. `snapshot_download(local_files_only=True)` returns that directory anyway, our validation only checked `model.bin` and the tokenizer, and CTranslate2 raises the opaque JSON error when `config.json` is absent. Reproduced locally by deleting only `config.json` from a healthy snapshot.

## Changes

- **Pin the model revision** to its current commit (unchanged since Nov 2024). The file layout we rely on is now frozen, and existing user caches already live under this revision, so no re-download is triggered.
- **Drop the hardcoded required-file list.** If CTranslate2 or the tokenizer fail to load the cached snapshot, re-sync with the Hub (which fetches only the missing files) and retry once. If that also fails, raise a clear "Fix Models" `ModelLoadError` instead of the raw C++ error.
- **Retry the online download** up to three times. The Hub resumes partial transfers, so a transient disconnect no longer restarts the 1.1 GB download.

Offline startup with a healthy cache is unchanged (no network call). Fix Models still wipes and re-downloads as a last resort.

## Testing

- End to end: copied a real cache, deleted `config.json` and `target_vocabulary.json`, ran `Translator.load()`. Got the reporter's exact error, then the repair, then a correct translation. Both files were restored.
- 9 new unit tests: cached path makes no network call, pinned revision is passed, repair from the JSON error, repair from a missing tokenizer, unrepairable case, download retry, persistent failure, fresh-install download.
- Full suite: 41 passed. Ruff clean.

Not tested: real mid-download disconnect (mocked only), the GUI flow, the CUDA path (no CUDA runtime on my machine; the fallback is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
