### PR TITLE
Add INTERPRETER_HOME to install outside the user profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,21 @@ jobs:
         run: python -m pip install pytest
 
       - name: Test Windows install scripts
-        run: python -m pytest -q tests/test_uninstall_windows.py
+        run: python -m pytest -q tests/test_uninstall_windows.py tests/test_install_scripts_posix.py tests/test_paths.py
+
+  posix-install-scripts:
+    name: POSIX install scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Test POSIX install scripts
+        run: python -m pytest -q tests/test_install_scripts_posix.py tests/test_paths.py

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By default everything is installed under your user profile (about 3 GB of applic
 
 **macOS/Linux:**
 ```bash
-INTERPRETER_HOME=/mnt/data/interpreter curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
+curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | INTERPRETER_HOME=/mnt/data/interpreter bash
 ```
 
 **Windows (PowerShell):**

--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/in
 
 Then run with `interpreter-v2`.
 
+### Installing to a Different Location
+
+By default everything is installed under your user profile (about 3 GB of application files plus 1.1 GB of models on first run). If your system drive is short on space, set `INTERPRETER_HOME` to a folder on another drive before running the installer:
+
+**macOS/Linux:**
+```bash
+INTERPRETER_HOME=/mnt/data/interpreter curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:INTERPRETER_HOME = "D:\interpreter"; powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/install.ps1 | iex"
+```
+
+The application, its Python runtime, and the downloaded models all go under that folder. The location is remembered in `~/.interpreter/install-dir`, so later upgrades and the uninstaller use it without setting the variable again. Only the small `interpreter-v2` launcher and your `config.yml` stay in your user profile.
+
+To change the location later, run the installer again with a new `INTERPRETER_HOME`. It removes the application from the old location and reinstalls it in the new one. Models are downloaded again on first run; the installer prints where the old ones are so you can delete them.
+
+To go back to the default location, run the uninstaller (see below) and then the plain installer.
+
 ## Upgrading
 
 To update to the latest version, run the installer again (see Installation above).

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,9 @@
 # install.ps1 - One-liner installer for interpreter-v2
 # Usage: powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/install.ps1 | iex"
+#
+# To install somewhere other than your user profile (for example on a second
+# drive), set INTERPRETER_HOME first. The choice is remembered for upgrades:
+#   $env:INTERPRETER_HOME = "D:\interpreter"; powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/install.ps1 | iex"
 
 $ErrorActionPreference = 'Stop'
 
@@ -13,10 +17,59 @@ Write-Host "Offline screen translator for Japanese retro games"
 Write-Host "Plan for at least 6 GB of free disk space, including first-run model downloads." -ForegroundColor Gray
 Write-Host ""
 
+# Resolve the install location. INTERPRETER_HOME wins; otherwise reuse the
+# location recorded by a previous run so plain re-runs upgrade in place. The
+# layout under the root mirrors src/interpreter/paths.py; keep them in sync:
+#   <root>\uv\tools    tool environment      <root>\uv-cache  install downloads
+#   <root>\uv\python   uv-managed Python     <root>\models    HuggingFace cache
+$configDir = Join-Path $env:USERPROFILE ".interpreter"
+$installRootFile = Join-Path $configDir "install-dir"
+$previousRoot = $null
+if (Test-Path -LiteralPath $installRootFile -PathType Leaf) {
+    $previousRoot = (Get-Content -LiteralPath $installRootFile -Raw).Trim()
+    if ($previousRoot) {
+        $previousRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($previousRoot).TrimEnd('\')
+    } else {
+        $previousRoot = $null
+    }
+}
+
+$installRoot = $null
+if ($env:INTERPRETER_HOME -and $env:INTERPRETER_HOME.Trim()) {
+    $installRoot = $env:INTERPRETER_HOME.Trim()
+} elseif ($previousRoot) {
+    $installRoot = $previousRoot
+}
+
+if ($installRoot) {
+    # Normalize relative paths against the shell's current directory (not the
+    # process directory, which PowerShell does not keep in sync).
+    $installRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($installRoot).TrimEnd('\')
+    $driveRoot = [System.IO.Path]::GetPathRoot($installRoot + '\').TrimEnd('\')
+    if ($installRoot -eq $driveRoot) {
+        Write-Host "Error: INTERPRETER_HOME must be a folder, not a drive root. Try $installRoot\interpreter" -ForegroundColor Red
+        exit 1
+    }
+    New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+    $env:UV_TOOL_DIR = Join-Path $installRoot "uv\tools"
+    $env:UV_PYTHON_INSTALL_DIR = Join-Path $installRoot "uv\python"
+    $installCacheDir = Join-Path $installRoot "uv-cache"
+    $modelsDir = Join-Path $installRoot "models"
+    Write-Host "Install location: $installRoot" -ForegroundColor Gray
+} else {
+    # Keep the large package downloads in an interpreter-owned cache. This lets
+    # the installer clean them after success or failure instead of leaving
+    # gigabytes in uv's shared cache after an interrupted install.
+    $installCacheDir = Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"
+    $modelsDir = $null
+    Write-Host "Install location: user profile (set INTERPRETER_HOME to choose another drive)" -ForegroundColor Gray
+}
+Write-Host ""
+
 # Check if uv is installed
 $uvPath = Get-Command uv -ErrorAction SilentlyContinue
 if (-not $uvPath) {
-    Write-Host "[1/2] Installing uv package manager..." -ForegroundColor Yellow
+    Write-Host "[1/3] Installing uv package manager..." -ForegroundColor Yellow
     Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
 
     # Refresh PATH to find uv
@@ -30,17 +83,44 @@ if (-not $uvPath) {
     }
     Write-Host "uv installed successfully!" -ForegroundColor Green
 } else {
-    Write-Host "[1/2] uv is already installed" -ForegroundColor Green
+    Write-Host "[1/3] uv is already installed" -ForegroundColor Green
+}
+
+# When the install location changes, remove the tool environment from the old
+# location first. Otherwise --force would leave a multi-gigabyte orphan behind.
+if ($previousRoot -ne $installRoot) {
+    if ($previousRoot) {
+        $previousToolDir = Join-Path $previousRoot "uv\tools"
+    } else {
+        $previousToolDir = Join-Path $env:APPDATA "uv\tools"
+    }
+    $previousToolEnvironment = Join-Path $previousToolDir "interpreter-v2"
+    if (Test-Path -LiteralPath $previousToolEnvironment) {
+        Write-Host "     Removing the previous installation from $previousToolDir" -ForegroundColor Yellow
+        $savedToolDir = $env:UV_TOOL_DIR
+        $env:UV_TOOL_DIR = $previousToolDir
+        $ErrorActionPreference = 'Continue'
+        uv tool uninstall interpreter-v2 2>$null | Out-Null
+        $ErrorActionPreference = 'Stop'
+        if ($savedToolDir) { $env:UV_TOOL_DIR = $savedToolDir } else { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue }
+        if (Test-Path -LiteralPath $previousToolEnvironment) {
+            Remove-Item -LiteralPath $previousToolEnvironment -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        if ($previousRoot) {
+            Write-Host "     Models downloaded by the previous installation remain in $previousRoot\models" -ForegroundColor Gray
+            Write-Host "     Delete that folder once the new installation works." -ForegroundColor Gray
+        } else {
+            Write-Host "     Models downloaded by the previous installation remain in the HuggingFace cache" -ForegroundColor Gray
+            Write-Host "     ($env:USERPROFILE\.cache\huggingface\hub). Delete the models--rtr46--* and" -ForegroundColor Gray
+            Write-Host "     models--entai2965--* folders there once the new installation works." -ForegroundColor Gray
+        }
+    }
 }
 
 # Install or upgrade interpreter-v2
 Write-Host "[2/3] Installing interpreter-v2 from PyPI..." -ForegroundColor Yellow
 Write-Host "     (this may take a minute on first install)" -ForegroundColor Gray
 # Use Python 3.12 explicitly - onnxruntime doesn't have wheels for 3.14 yet
-# Keep the large package downloads in an interpreter-owned cache. This lets the
-# installer clean them after success or failure instead of leaving gigabytes in
-# uv's shared cache after an interrupted install.
-$installCacheDir = Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"
 # Temporarily allow errors so uv's progress output (on stderr) doesn't stop the script
 $ErrorActionPreference = 'Continue'
 try {
@@ -67,10 +147,19 @@ $ErrorActionPreference = 'SilentlyContinue'
 uv tool update-shell | Out-Null
 $ErrorActionPreference = 'Stop'
 
+# Record the install location so upgrades, the app, and the uninstaller find it.
+if ($installRoot) {
+    New-Item -ItemType Directory -Force -Path $configDir | Out-Null
+    # Windows PowerShell 5.1 adds a byte order mark with -Encoding UTF8; the app
+    # and the bash scripts read this file, so write plain UTF-8.
+    [System.IO.File]::WriteAllText($installRootFile, $installRoot, (New-Object System.Text.UTF8Encoding $false))
+}
+
 # Pre-compile bytecode and warm up OS caches
 Write-Host "[3/3] Optimizing for fast startup..." -ForegroundColor Yellow
-$toolDir = "$env:APPDATA\uv\tools\interpreter-v2"
-if (Test-Path $toolDir) {
+$toolRoot = if ($env:UV_TOOL_DIR) { $env:UV_TOOL_DIR } else { Join-Path $env:APPDATA "uv\tools" }
+$toolDir = Join-Path $toolRoot "interpreter-v2"
+if (Test-Path -LiteralPath "$toolDir\Scripts\python.exe") {
     & "$toolDir\Scripts\python.exe" -m compileall -q "$toolDir\Lib" 2>$null
     # Warm up caches (Windows Defender, etc.) by triggering the full
     # module-level import chain via --help (no GUI, exits cleanly).
@@ -82,6 +171,10 @@ Write-Host "========================================" -ForegroundColor Green
 Write-Host "  Installation complete!" -ForegroundColor Green
 Write-Host "========================================" -ForegroundColor Green
 Write-Host ""
+if ($installRoot) {
+    Write-Host "Installed to $installRoot (models will download to $modelsDir)" -ForegroundColor Gray
+    Write-Host ""
+}
 Write-Host "To start, run:" -ForegroundColor White
 Write-Host ""
 Write-Host "  interpreter-v2" -ForegroundColor Cyan

--- a/install.ps1
+++ b/install.ps1
@@ -51,6 +51,9 @@ if ($installRoot) {
         exit 1
     }
     New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+    # The uninstaller only removes folders next to this marker, so a mistyped
+    # or shared INTERPRETER_HOME never has unrelated content deleted.
+    Set-Content -LiteralPath (Join-Path $installRoot ".interpreter-v2") -Value "Created by the interpreter-v2 installer. The uninstaller removes the uv, uv-cache and models folders next to this file."
     $env:UV_TOOL_DIR = Join-Path $installRoot "uv\tools"
     $env:UV_PYTHON_INSTALL_DIR = Join-Path $installRoot "uv\python"
     $installCacheDir = Join-Path $installRoot "uv-cache"
@@ -84,37 +87,6 @@ if (-not $uvPath) {
     Write-Host "uv installed successfully!" -ForegroundColor Green
 } else {
     Write-Host "[1/3] uv is already installed" -ForegroundColor Green
-}
-
-# When the install location changes, remove the tool environment from the old
-# location first. Otherwise --force would leave a multi-gigabyte orphan behind.
-if ($previousRoot -ne $installRoot) {
-    if ($previousRoot) {
-        $previousToolDir = Join-Path $previousRoot "uv\tools"
-    } else {
-        $previousToolDir = Join-Path $env:APPDATA "uv\tools"
-    }
-    $previousToolEnvironment = Join-Path $previousToolDir "interpreter-v2"
-    if (Test-Path -LiteralPath $previousToolEnvironment) {
-        Write-Host "     Removing the previous installation from $previousToolDir" -ForegroundColor Yellow
-        $savedToolDir = $env:UV_TOOL_DIR
-        $env:UV_TOOL_DIR = $previousToolDir
-        $ErrorActionPreference = 'Continue'
-        uv tool uninstall interpreter-v2 2>$null | Out-Null
-        $ErrorActionPreference = 'Stop'
-        if ($savedToolDir) { $env:UV_TOOL_DIR = $savedToolDir } else { Remove-Item Env:UV_TOOL_DIR -ErrorAction SilentlyContinue }
-        if (Test-Path -LiteralPath $previousToolEnvironment) {
-            Remove-Item -LiteralPath $previousToolEnvironment -Recurse -Force -ErrorAction SilentlyContinue
-        }
-        if ($previousRoot) {
-            Write-Host "     Models downloaded by the previous installation remain in $previousRoot\models" -ForegroundColor Gray
-            Write-Host "     Delete that folder once the new installation works." -ForegroundColor Gray
-        } else {
-            Write-Host "     Models downloaded by the previous installation remain in the HuggingFace cache" -ForegroundColor Gray
-            Write-Host "     ($env:USERPROFILE\.cache\huggingface\hub). Delete the models--rtr46--* and" -ForegroundColor Gray
-            Write-Host "     models--entai2965--* folders there once the new installation works." -ForegroundColor Gray
-        }
-    }
 }
 
 # Install or upgrade interpreter-v2
@@ -153,6 +125,32 @@ if ($installRoot) {
     # Windows PowerShell 5.1 adds a byte order mark with -Encoding UTF8; the app
     # and the bash scripts read this file, so write plain UTF-8.
     [System.IO.File]::WriteAllText($installRootFile, $installRoot, (New-Object System.Text.UTF8Encoding $false))
+}
+
+# The install location changed: now that the new installation works, remove
+# the tool environment left in the old location so a multi-gigabyte orphan is
+# not left behind. Only the directory is deleted. Running `uv tool uninstall`
+# there would also remove the launcher the new installation just created in
+# the shared bin directory.
+if ($previousRoot -ne $installRoot) {
+    if ($previousRoot) {
+        $previousToolDir = Join-Path $previousRoot "uv\tools"
+    } else {
+        $previousToolDir = Join-Path $env:APPDATA "uv\tools"
+    }
+    $previousToolEnvironment = Join-Path $previousToolDir "interpreter-v2"
+    if (Test-Path -LiteralPath $previousToolEnvironment) {
+        Write-Host "     Removing the previous installation from $previousToolDir" -ForegroundColor Yellow
+        Remove-Item -LiteralPath $previousToolEnvironment -Recurse -Force -ErrorAction SilentlyContinue
+        if ($previousRoot) {
+            Write-Host "     Models downloaded by the previous installation remain in $previousRoot\models" -ForegroundColor Gray
+            Write-Host "     Delete that folder once the new installation works." -ForegroundColor Gray
+        } else {
+            Write-Host "     Models downloaded by the previous installation remain in the HuggingFace cache" -ForegroundColor Gray
+            Write-Host "     ($env:USERPROFILE\.cache\huggingface\hub). Delete the models--rtr46--* and" -ForegroundColor Gray
+            Write-Host "     models--entai2965--* folders there once the new installation works." -ForegroundColor Gray
+        }
+    }
 }
 
 # Pre-compile bytecode and warm up OS caches

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # install.sh - One-liner installer for interpreter-v2
 # Usage: curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
+#
+# To install somewhere other than your home directory (for example on a second
+# drive), set INTERPRETER_HOME first. The choice is remembered for upgrades:
+#   INTERPRETER_HOME=/mnt/data/interpreter curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
 
 set -e
 
@@ -22,6 +26,50 @@ fi
 echo ""
 echo -e "${CYAN}=== interpreter-v2 Installer ===${NC}"
 echo "Offline screen translator for Japanese retro games"
+echo -e "${GRAY}Plan for at least 6 GB of free disk space, including first-run model downloads.${NC}"
+echo ""
+
+# Resolve the install location. INTERPRETER_HOME wins; otherwise reuse the
+# location recorded by a previous run so plain re-runs upgrade in place. The
+# layout under the root mirrors src/interpreter/paths.py; keep them in sync:
+#   <root>/uv/tools    tool environment      <root>/uv-cache  install downloads
+#   <root>/uv/python   uv-managed Python     <root>/models    HuggingFace cache
+CONFIG_DIR="$HOME/.interpreter"
+INSTALL_ROOT_FILE="$CONFIG_DIR/install-dir"
+PREVIOUS_ROOT=""
+if [ -f "$INSTALL_ROOT_FILE" ]; then
+	PREVIOUS_ROOT=$(tr -d '\r\n' <"$INSTALL_ROOT_FILE")
+	PREVIOUS_ROOT="${PREVIOUS_ROOT%/}"
+fi
+
+INSTALL_ROOT="${INTERPRETER_HOME:-$PREVIOUS_ROOT}"
+UV_CACHE_ARGS=()
+if [ -n "$INSTALL_ROOT" ]; then
+	# Expand a leading ~ and make relative paths absolute.
+	INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
+	case "$INSTALL_ROOT" in
+	/*) ;;
+	*) INSTALL_ROOT="$PWD/$INSTALL_ROOT" ;;
+	esac
+	INSTALL_ROOT="${INSTALL_ROOT%/}"
+	if [ -z "$INSTALL_ROOT" ]; then
+		echo -e "${RED}Error: INTERPRETER_HOME must be a directory, not the filesystem root. Try /opt/interpreter${NC}"
+		exit 1
+	fi
+	mkdir -p "$INSTALL_ROOT"
+	export UV_TOOL_DIR="$INSTALL_ROOT/uv/tools"
+	export UV_PYTHON_INSTALL_DIR="$INSTALL_ROOT/uv/python"
+	# Keep the multi-gigabyte package downloads off the home drive too, and
+	# remove them after the install instead of leaving them in uv's cache.
+	INSTALL_CACHE_DIR="$INSTALL_ROOT/uv-cache"
+	UV_CACHE_ARGS=(--cache-dir "$INSTALL_CACHE_DIR")
+	MODELS_DIR="$INSTALL_ROOT/models"
+	echo -e "${GRAY}Install location: $INSTALL_ROOT${NC}"
+else
+	INSTALL_CACHE_DIR=""
+	MODELS_DIR=""
+	echo -e "${GRAY}Install location: home directory (set INTERPRETER_HOME to choose another drive)${NC}"
+fi
 echo ""
 
 # Check if uv is installed
@@ -42,11 +90,40 @@ else
 	echo -e "${GREEN}[1/${TOTAL_STEPS}] uv is already installed${NC}"
 fi
 
+# When the install location changes, remove the tool environment from the old
+# location first. Otherwise the reinstall would leave a multi-gigabyte orphan.
+if [ "$PREVIOUS_ROOT" != "$INSTALL_ROOT" ]; then
+	if [ -n "$PREVIOUS_ROOT" ]; then
+		PREVIOUS_TOOL_DIR="$PREVIOUS_ROOT/uv/tools"
+	else
+		PREVIOUS_TOOL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools"
+	fi
+	if [ -d "$PREVIOUS_TOOL_DIR/interpreter-v2" ]; then
+		echo -e "${YELLOW}     Removing the previous installation from $PREVIOUS_TOOL_DIR${NC}"
+		UV_TOOL_DIR="$PREVIOUS_TOOL_DIR" uv tool uninstall interpreter-v2 >/dev/null 2>&1 || true
+		rm -rf "$PREVIOUS_TOOL_DIR/interpreter-v2"
+		if [ -n "$PREVIOUS_ROOT" ]; then
+			echo -e "${GRAY}     Models downloaded by the previous installation remain in $PREVIOUS_ROOT/models${NC}"
+			echo -e "${GRAY}     Delete that folder once the new installation works.${NC}"
+		else
+			echo -e "${GRAY}     Models downloaded by the previous installation remain in the HuggingFace cache${NC}"
+			echo -e "${GRAY}     (~/.cache/huggingface/hub). Delete the models--rtr46--* and models--entai2965--*${NC}"
+			echo -e "${GRAY}     folders there once the new installation works.${NC}"
+		fi
+	fi
+fi
+
 # Install or upgrade interpreter-v2
 echo -e "${YELLOW}[2/${TOTAL_STEPS}] Installing interpreter-v2 from PyPI...${NC}"
 echo -e "${GRAY}     (this may take a minute on first install)${NC}"
 # Use Python 3.12 - uv-managed Python includes tkinter, system Python 3.13+ often doesn't
-if ! uv tool install --upgrade --python 3.12 interpreter-v2 2>&1; then
+INSTALL_OK=1
+uv tool install --upgrade --python 3.12 "${UV_CACHE_ARGS[@]}" interpreter-v2 2>&1 || INSTALL_OK=0
+if [ -n "$INSTALL_CACHE_DIR" ]; then
+	uv cache clean --cache-dir "$INSTALL_CACHE_DIR" >/dev/null 2>&1 || true
+	rm -rf "$INSTALL_CACHE_DIR"
+fi
+if [ "$INSTALL_OK" -ne 1 ]; then
 	echo ""
 	echo -e "${RED}Installation failed!${NC}"
 	echo -e "${YELLOW}This may be due to missing dependencies. Try:${NC}"
@@ -56,9 +133,15 @@ if ! uv tool install --upgrade --python 3.12 interpreter-v2 2>&1; then
 fi
 uv tool update-shell >/dev/null 2>&1 || true
 
+# Record the install location so upgrades, the app, and the uninstaller find it.
+if [ -n "$INSTALL_ROOT" ]; then
+	mkdir -p "$CONFIG_DIR"
+	printf '%s' "$INSTALL_ROOT" >"$INSTALL_ROOT_FILE"
+fi
+
 # Pre-compile bytecode and warm up OS caches
 echo -e "${YELLOW}[3/${TOTAL_STEPS}] Optimizing for fast startup...${NC}"
-TOOL_DIR="$HOME/.local/share/uv/tools/interpreter-v2"
+TOOL_DIR="${UV_TOOL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools}/interpreter-v2"
 if [ -d "$TOOL_DIR" ]; then
 	# Compile bytecode (exclude .tmpl.py template files that aren't valid Python)
 	"$TOOL_DIR/bin/python" -m compileall -q -x '\.tmpl\.py$' "$TOOL_DIR/lib" 2>/dev/null || true
@@ -136,6 +219,10 @@ echo -e "${GREEN}========================================${NC}"
 echo -e "${GREEN}  Installation complete!${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo ""
+if [ -n "$INSTALL_ROOT" ]; then
+	echo -e "${GRAY}Installed to $INSTALL_ROOT (models will download to $MODELS_DIR)${NC}"
+	echo ""
+fi
 echo "To start, run:"
 echo ""
 echo -e "  ${CYAN}interpreter-v2${NC}"

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 #
 # To install somewhere other than your home directory (for example on a second
 # drive), set INTERPRETER_HOME first. The choice is remembered for upgrades:
-#   INTERPRETER_HOME=/mnt/data/interpreter curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
+#   curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | INTERPRETER_HOME=/mnt/data/interpreter bash
 
 set -e
 
@@ -57,6 +57,9 @@ if [ -n "$INSTALL_ROOT" ]; then
 		exit 1
 	fi
 	mkdir -p "$INSTALL_ROOT"
+	# The uninstaller only removes folders next to this marker, so a mistyped
+	# or shared INTERPRETER_HOME never has unrelated content deleted.
+	echo "Created by the interpreter-v2 installer. The uninstaller removes the uv, uv-cache and models folders next to this file." >"$INSTALL_ROOT/.interpreter-v2"
 	export UV_TOOL_DIR="$INSTALL_ROOT/uv/tools"
 	export UV_PYTHON_INSTALL_DIR="$INSTALL_ROOT/uv/python"
 	# Keep the multi-gigabyte package downloads off the home drive too, and
@@ -90,35 +93,26 @@ else
 	echo -e "${GREEN}[1/${TOTAL_STEPS}] uv is already installed${NC}"
 fi
 
-# When the install location changes, remove the tool environment from the old
-# location first. Otherwise the reinstall would leave a multi-gigabyte orphan.
-if [ "$PREVIOUS_ROOT" != "$INSTALL_ROOT" ]; then
-	if [ -n "$PREVIOUS_ROOT" ]; then
-		PREVIOUS_TOOL_DIR="$PREVIOUS_ROOT/uv/tools"
-	else
-		PREVIOUS_TOOL_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools"
-	fi
-	if [ -d "$PREVIOUS_TOOL_DIR/interpreter-v2" ]; then
-		echo -e "${YELLOW}     Removing the previous installation from $PREVIOUS_TOOL_DIR${NC}"
-		UV_TOOL_DIR="$PREVIOUS_TOOL_DIR" uv tool uninstall interpreter-v2 >/dev/null 2>&1 || true
-		rm -rf "$PREVIOUS_TOOL_DIR/interpreter-v2"
-		if [ -n "$PREVIOUS_ROOT" ]; then
-			echo -e "${GRAY}     Models downloaded by the previous installation remain in $PREVIOUS_ROOT/models${NC}"
-			echo -e "${GRAY}     Delete that folder once the new installation works.${NC}"
-		else
-			echo -e "${GRAY}     Models downloaded by the previous installation remain in the HuggingFace cache${NC}"
-			echo -e "${GRAY}     (~/.cache/huggingface/hub). Delete the models--rtr46--* and models--entai2965--*${NC}"
-			echo -e "${GRAY}     folders there once the new installation works.${NC}"
-		fi
-	fi
-fi
-
 # Install or upgrade interpreter-v2
 echo -e "${YELLOW}[2/${TOTAL_STEPS}] Installing interpreter-v2 from PyPI...${NC}"
 echo -e "${GRAY}     (this may take a minute on first install)${NC}"
 # Use Python 3.12 - uv-managed Python includes tkinter, system Python 3.13+ often doesn't
+# When the install location changes, the launcher from the old location still
+# exists in the shared bin directory; --force lets uv replace it.
+PREVIOUS_TOOL_ENV=""
+if [ "$PREVIOUS_ROOT" != "$INSTALL_ROOT" ]; then
+	if [ -n "$PREVIOUS_ROOT" ]; then
+		PREVIOUS_TOOL_ENV="$PREVIOUS_ROOT/uv/tools/interpreter-v2"
+	else
+		PREVIOUS_TOOL_ENV="${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools/interpreter-v2"
+	fi
+fi
+UV_FORCE_ARGS=()
+if [ -n "$PREVIOUS_TOOL_ENV" ] && [ -d "$PREVIOUS_TOOL_ENV" ]; then
+	UV_FORCE_ARGS=(--force)
+fi
 INSTALL_OK=1
-uv tool install --upgrade --python 3.12 "${UV_CACHE_ARGS[@]}" interpreter-v2 2>&1 || INSTALL_OK=0
+uv tool install "${UV_FORCE_ARGS[@]}" --upgrade --python 3.12 "${UV_CACHE_ARGS[@]}" interpreter-v2 2>&1 || INSTALL_OK=0
 if [ -n "$INSTALL_CACHE_DIR" ]; then
 	uv cache clean --cache-dir "$INSTALL_CACHE_DIR" >/dev/null 2>&1 || true
 	rm -rf "$INSTALL_CACHE_DIR"
@@ -137,6 +131,24 @@ uv tool update-shell >/dev/null 2>&1 || true
 if [ -n "$INSTALL_ROOT" ]; then
 	mkdir -p "$CONFIG_DIR"
 	printf '%s' "$INSTALL_ROOT" >"$INSTALL_ROOT_FILE"
+fi
+
+# The install location changed: now that the new installation works, remove
+# the tool environment left in the old location so a multi-gigabyte orphan is
+# not left behind. Only the directory is deleted. Running `uv tool uninstall`
+# there would also remove the launcher the new installation just created in
+# the shared bin directory.
+if [ -n "$PREVIOUS_TOOL_ENV" ] && [ -d "$PREVIOUS_TOOL_ENV" ]; then
+	echo -e "${YELLOW}     Removing the previous installation from $(dirname "$PREVIOUS_TOOL_ENV")${NC}"
+	rm -rf "$PREVIOUS_TOOL_ENV"
+	if [ -n "$PREVIOUS_ROOT" ]; then
+		echo -e "${GRAY}     Models downloaded by the previous installation remain in $PREVIOUS_ROOT/models${NC}"
+		echo -e "${GRAY}     Delete that folder once the new installation works.${NC}"
+	else
+		echo -e "${GRAY}     Models downloaded by the previous installation remain in the HuggingFace cache${NC}"
+		echo -e "${GRAY}     (~/.cache/huggingface/hub). Delete the models--rtr46--* and models--entai2965--*${NC}"
+		echo -e "${GRAY}     folders there once the new installation works.${NC}"
+	fi
 fi
 
 # Pre-compile bytecode and warm up OS caches

--- a/src/interpreter/__init__.py
+++ b/src/interpreter/__init__.py
@@ -20,6 +20,11 @@ __version__ = version("interpreter-v2")
 
 def main():
     """Entry point for the application."""
+    from . import paths
+
+    # Must precede any import of huggingface_hub (pulled in by the GUI stack).
+    paths.apply_environment()
+
     from .gui import run
 
     return run()

--- a/src/interpreter/__main__.py
+++ b/src/interpreter/__main__.py
@@ -3,17 +3,12 @@
 This module is executed when running:
 - python -m interpreter
 - interpreter-v2 (via pyproject.toml entry point)
+
+Both routes go through interpreter.main so that startup work such as
+resolving the install location happens before the GUI is imported.
 """
 
-import faulthandler
-import signal
-
-# Enable faulthandler to dump thread stacks on SIGUSR1 (Unix only)
-# Usage: kill -USR1 <pid>  (find pid with: pgrep -f interpreter)
-if hasattr(signal, "SIGUSR1"):
-    faulthandler.register(signal.SIGUSR1, all_threads=True)
-
-from .gui import run
+from . import main
 
 if __name__ == "__main__":
-    run()
+    main()

--- a/src/interpreter/models.py
+++ b/src/interpreter/models.py
@@ -19,7 +19,9 @@ def get_hf_cache_path(repo_id: str) -> Path:
     Returns:
         Path to the cache directory for this repo.
     """
-    # HuggingFace stores repos as: ~/.cache/huggingface/hub/models--org--repo/
+    # HuggingFace stores repos as: <hub cache>/models--org--repo/. The hub cache
+    # is ~/.cache/huggingface/hub unless a custom install location redirected it
+    # (see paths.apply_environment, which runs before this module is imported).
     repo_folder = "models--" + repo_id.replace("/", "--")
     return Path(HF_HUB_CACHE) / repo_folder
 

--- a/src/interpreter/paths.py
+++ b/src/interpreter/paths.py
@@ -45,7 +45,9 @@ def get_install_root() -> Path | None:
             return None
     if not value:
         return None
-    return Path(os.path.expanduser(value))
+    # Anchor relative values to the working directory now, so the cache path
+    # does not silently depend on where the app happens to be launched from.
+    return Path(os.path.abspath(os.path.expanduser(value)))
 
 
 def get_models_dir() -> Path | None:

--- a/src/interpreter/paths.py
+++ b/src/interpreter/paths.py
@@ -1,0 +1,69 @@
+"""Resolution of the optional custom install location.
+
+By default everything lives under the user's home directory: the uv tool
+environment, the uv-managed Python, and the HuggingFace model cache. Users with
+a small system drive can instead point the installer at another location via the
+INTERPRETER_HOME environment variable. The installer records that location in
+~/.interpreter/install-dir so later runs (and the app itself) find it without
+the variable being set again.
+
+Layout under the install location::
+
+    <root>/uv/tools     uv tool environments (UV_TOOL_DIR)
+    <root>/uv/python    uv-managed Python (UV_PYTHON_INSTALL_DIR)
+    <root>/uv-cache     package downloads, removed after install
+    <root>/models       HuggingFace hub cache (HF_HUB_CACHE)
+
+The installers and uninstallers mirror this layout; keep them in sync.
+"""
+
+import os
+from pathlib import Path
+
+INSTALL_ROOT_ENV = "INTERPRETER_HOME"
+INSTALL_ROOT_FILE_NAME = "install-dir"
+MODELS_DIR_NAME = "models"
+
+
+def get_config_dir() -> Path:
+    """Directory holding config.yml and the install location pointer."""
+    return Path.home() / ".interpreter"
+
+
+def get_install_root() -> Path | None:
+    """Return the custom install location, or None for the default layout.
+
+    INTERPRETER_HOME takes precedence over the pointer file written by the
+    installer. Blank values are treated as unset.
+    """
+    value = os.environ.get(INSTALL_ROOT_ENV, "").strip()
+    if not value:
+        pointer = get_config_dir() / INSTALL_ROOT_FILE_NAME
+        try:
+            value = pointer.read_text(encoding="utf-8-sig").strip()
+        except OSError:
+            return None
+    if not value:
+        return None
+    return Path(os.path.expanduser(value))
+
+
+def get_models_dir() -> Path | None:
+    """Return the model cache directory under the install location, if any."""
+    root = get_install_root()
+    if root is None:
+        return None
+    return root / MODELS_DIR_NAME
+
+
+def apply_environment() -> None:
+    """Point huggingface_hub at the custom model directory.
+
+    Must run before huggingface_hub is imported anywhere, because it reads
+    HF_HUB_CACHE once at import time. An install location always wins over a
+    generic HF_HOME/HF_HUB_CACHE so that models land where the user asked the
+    installer to put them.
+    """
+    models_dir = get_models_dir()
+    if models_dir is not None:
+        os.environ["HF_HUB_CACHE"] = str(models_dir)

--- a/tests/test_install_scripts_posix.py
+++ b/tests/test_install_scripts_posix.py
@@ -171,6 +171,7 @@ def test_install_to_custom_location(tmp_path: Path) -> None:
     assert f"cache clean --cache-dir {root_posix}/uv-cache" in lines
     assert not any(line.startswith("tool uninstall") for line in lines)
     assert root.is_dir()
+    assert (root / ".interpreter-v2").is_file()
     assert not (root / "uv-cache").exists()
     assert _pointer(home).read_text(encoding="utf-8") == root_posix
     assert f"Installed to {root_posix}" in result.stdout
@@ -233,9 +234,14 @@ def test_moving_from_home_removes_previous_environment(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout + result.stderr
     lines = _log_lines(command_log)
-    uninstall_index = lines.index("tool uninstall interpreter-v2")
-    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={_posix(home)}/.local/share/uv/tools"
-    assert uninstall_index < lines.index(next(line for line in lines if line.startswith("tool install")))
+    # --force lets uv replace the launcher left in the shared bin directory.
+    install_index = lines.index(
+        f"tool install --force --upgrade --python 3.12 --cache-dir {_posix(root)}/uv-cache interpreter-v2"
+    )
+    assert lines[install_index + 1] == f"UV_TOOL_DIR={_posix(root)}/uv/tools"
+    # The old environment is deleted directly: `uv tool uninstall` there would
+    # also remove the launcher the new install just created in the shared bin.
+    assert not any(line.startswith("tool uninstall") for line in lines)
     assert not default_environment.exists()
     assert "remain in the HuggingFace cache" in result.stdout
 
@@ -253,8 +259,10 @@ def test_moving_between_custom_locations_removes_previous_environment(tmp_path: 
 
     assert result.returncode == 0, result.stdout + result.stderr
     lines = _log_lines(command_log)
-    uninstall_index = lines.index("tool uninstall interpreter-v2")
-    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={_posix(old_root)}/uv/tools"
+    assert (
+        f"tool install --force --upgrade --python 3.12 --cache-dir {_posix(new_root)}/uv-cache interpreter-v2" in lines
+    )
+    assert not any(line.startswith("tool uninstall") for line in lines)
     assert not (old_root / "uv" / "tools" / "interpreter-v2").exists()
     # Models are never deleted by the installer; the user is told where they are.
     assert (old_root / "models" / MODEL_CACHE_NAMES[0]).exists()
@@ -262,8 +270,10 @@ def test_moving_between_custom_locations_removes_previous_environment(tmp_path: 
     assert _pointer(home).read_text(encoding="utf-8") == _posix(new_root)
 
 
-def test_failed_install_cleans_cache_and_records_nothing(tmp_path: Path) -> None:
+def test_failed_install_keeps_previous_install(tmp_path: Path) -> None:
     environment, home, _, command_log = _environment(tmp_path)
+    default_environment = home / ".local" / "share" / "uv" / "tools" / "interpreter-v2"
+    _create_file(default_environment / "pyvenv.cfg")
     root = tmp_path / "other-drive" / "interpreter"
     environment["INTERPRETER_HOME"] = _posix(root)
     environment["UV_TEST_INSTALL_EXIT"] = "42"
@@ -275,13 +285,17 @@ def test_failed_install_cleans_cache_and_records_nothing(tmp_path: Path) -> None
     assert "Installation failed" in result.stdout
     assert f"cache clean --cache-dir {_posix(root)}/uv-cache" in _log_lines(command_log)
     assert not (root / "uv-cache").exists()
+    # Nothing is recorded and the working installation is left untouched.
     assert not _pointer(home).exists()
+    assert (default_environment / "pyvenv.cfg").exists()
 
 
 # --- uninstall.sh -------------------------------------------------------------
 
 
-def _populate_install(root: Path, home: Path, model_hub: Path) -> Path:
+def _populate_install(root: Path, home: Path, model_hub: Path, *, marker: bool = True) -> Path:
+    if marker:
+        _create_file(root / ".interpreter-v2", "Created by the interpreter-v2 installer.")
     _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
     _create_file(root / "uv" / "python" / "cpython-3.12" / "bin" / "python")
     _create_file(root / "uv-cache" / "partial-download.whl")
@@ -332,6 +346,27 @@ def test_uninstall_keeps_location_with_other_files_and_works_without_uv(tmp_path
     assert (root / "my-notes.txt").read_text(encoding="utf-8") == "keep me"
     assert "Kept" in result.stdout
     assert not (home / ".interpreter").exists()
+
+
+def test_uninstall_leaves_location_without_installer_marker_alone(tmp_path: Path) -> None:
+    """A mistyped or shared INTERPRETER_HOME must not have its contents deleted."""
+    environment, home, model_hub, _ = _environment(tmp_path)
+    root = tmp_path / "shared-tools"
+    _populate_install(root, home, model_hub, marker=False)
+    _create_file(root / "uv" / "tools" / "other-tool" / "pyvenv.cfg")
+    environment["INTERPRETER_HOME"] = _posix(root)
+
+    result = _run(UNINSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "was not created by the interpreter-v2 installer" in result.stdout
+    # Only interpreter-v2's own tool environment goes; everything else stays.
+    assert not (root / "uv" / "tools" / "interpreter-v2").exists()
+    assert (root / "uv" / "tools" / "other-tool" / "pyvenv.cfg").exists()
+    assert (root / "uv" / "python").exists()
+    assert (root / "uv-cache").exists()
+    for model_cache_name in MODEL_CACHE_NAMES:
+        assert (root / "models" / model_cache_name).exists()
 
 
 def test_uninstall_without_custom_location_removes_default_models(tmp_path: Path) -> None:

--- a/tests/test_install_scripts_posix.py
+++ b/tests/test_install_scripts_posix.py
@@ -1,0 +1,358 @@
+"""Integration tests for install.sh and uninstall.sh.
+
+They run under bash with a stub ``uv`` on PATH, so they work on Linux, macOS,
+and Windows with Git Bash. ``uname`` is stubbed to report macOS so the
+Linux-only dependency checks (which need system libraries) are skipped.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SCRIPT = REPO_ROOT / "install.sh"
+UNINSTALL_SCRIPT = REPO_ROOT / "uninstall.sh"
+MODEL_CACHE_NAMES = (
+    "models--rtr46--meiki.text.detect.v0",
+    "models--rtr46--meiki.txt.recognition.v0",
+    "models--entai2965--sugoi-v4-ja-en-ctranslate2",
+)
+
+
+def _find_bash() -> str | None:
+    if sys.platform == "win32":
+        # Prefer Git Bash; the WindowsApps stub launches WSL instead.
+        for candidate in (
+            Path(os.environ.get("PROGRAMFILES", r"C:\Program Files")) / "Git" / "bin" / "bash.exe",
+            Path(os.environ.get("PROGRAMFILES", r"C:\Program Files")) / "Git" / "usr" / "bin" / "bash.exe",
+        ):
+            if candidate.is_file():
+                return str(candidate)
+        found = shutil.which("bash")
+        if found and "WindowsApps" not in found:
+            return found
+        return None
+    return shutil.which("bash")
+
+
+BASH = _find_bash()
+
+pytestmark = pytest.mark.skipif(BASH is None, reason="requires bash")
+
+
+def _minimal_path(fake_bin: Path) -> str:
+    """PATH with the stubs first and only core utilities after, never a real uv."""
+    if sys.platform == "win32":
+        git_usr_bin = Path(BASH).resolve().parents[1] / "usr" / "bin"
+        return os.pathsep.join([str(fake_bin), str(git_usr_bin)])
+    return os.pathsep.join([str(fake_bin), "/usr/bin", "/bin"])
+
+
+def _posix(path: Path) -> str:
+    """Path as the bash scripts see it (MSYS form on Windows)."""
+    if sys.platform == "win32":
+        result = subprocess.run([BASH, "-c", 'cygpath -u "$0"', str(path)], check=True, capture_output=True, text=True)
+        return result.stdout.strip()
+    return str(path)
+
+
+def _create_file(path: Path, content: str = "test") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _create_executable(path: Path, content: str) -> None:
+    _create_file(path, content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+UV_STUB = """#!/bin/bash
+printf '%s\\n' "$*" >>"$UV_TEST_LOG"
+printf 'UV_TOOL_DIR=%s\\n' "${UV_TOOL_DIR:-}" >>"$UV_TEST_LOG"
+printf 'UV_PYTHON_INSTALL_DIR=%s\\n' "${UV_PYTHON_INSTALL_DIR:-}" >>"$UV_TEST_LOG"
+case "$1 $2" in
+"tool dir") echo "${UV_TOOL_DIR:-$HOME/.local/share/uv/tools}" ;;
+"tool list") echo "interpreter-v2 v2.17.6" ;;
+"tool install") exit "${UV_TEST_INSTALL_EXIT:-0}" ;;
+esac
+exit 0
+"""
+
+
+def _environment(tmp_path: Path, *, with_uv: bool = True) -> tuple[dict[str, str], Path, Path, Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    fake_bin = tmp_path / "fake-bin"
+    command_log = tmp_path / "uv-commands.log"
+    _create_executable(fake_bin / "uname", "#!/bin/bash\necho Darwin\n")
+    if with_uv:
+        _create_executable(fake_bin / "uv", UV_STUB)
+
+    model_hub = tmp_path / "huggingface" / "hub"
+    environment = os.environ.copy()
+    for name in (
+        "INTERPRETER_HOME",
+        "UV_TOOL_DIR",
+        "UV_PYTHON_INSTALL_DIR",
+        "UV_CACHE_DIR",
+        "HF_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+    ):
+        environment.pop(name, None)
+    environment.update(
+        {
+            "HOME": _posix(home),
+            "USERPROFILE": str(home),
+            "HF_HUB_CACHE": _posix(model_hub),
+            "PATH": _minimal_path(fake_bin),
+            "UV_TEST_LOG": _posix(command_log),
+        }
+    )
+    return environment, home, model_hub, command_log
+
+
+def _run(script: Path, environment: dict[str, str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [BASH, _posix(script)],
+        check=False,
+        capture_output=True,
+        env=environment,
+        cwd=cwd,
+        text=True,
+        timeout=60,
+    )
+
+
+def _log_lines(command_log: Path) -> list[str]:
+    return command_log.read_text(encoding="utf-8").splitlines()
+
+
+def _pointer(home: Path) -> Path:
+    return home / ".interpreter" / "install-dir"
+
+
+# --- install.sh ---------------------------------------------------------------
+
+
+def test_default_install_keeps_previous_behavior(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    assert "tool install --upgrade --python 3.12 interpreter-v2" in lines
+    assert "UV_TOOL_DIR=" in lines
+    assert not _pointer(home).exists()
+    assert "home directory" in result.stdout
+
+
+def test_install_to_custom_location(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    root_posix = _posix(root)
+    environment["INTERPRETER_HOME"] = root_posix
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    install_index = lines.index(
+        f"tool install --upgrade --python 3.12 --cache-dir {root_posix}/uv-cache interpreter-v2"
+    )
+    assert lines[install_index + 1] == f"UV_TOOL_DIR={root_posix}/uv/tools"
+    assert lines[install_index + 2] == f"UV_PYTHON_INSTALL_DIR={root_posix}/uv/python"
+    assert f"cache clean --cache-dir {root_posix}/uv-cache" in lines
+    assert not any(line.startswith("tool uninstall") for line in lines)
+    assert root.is_dir()
+    assert not (root / "uv-cache").exists()
+    assert _pointer(home).read_text(encoding="utf-8") == root_posix
+    assert f"Installed to {root_posix}" in result.stdout
+    assert f"{root_posix}/models" in result.stdout
+
+
+def test_relative_and_tilde_locations_are_normalized(tmp_path: Path) -> None:
+    environment, home, _, _ = _environment(tmp_path)
+    environment["INTERPRETER_HOME"] = "~/apps/interpreter"
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _pointer(home).read_text(encoding="utf-8") == f"{_posix(home)}/apps/interpreter"
+
+    environment["INTERPRETER_HOME"] = "relative/interpreter/"
+    result = _run(INSTALL_SCRIPT, environment, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _pointer(home).read_text(encoding="utf-8") == f"{_posix(tmp_path)}/relative/interpreter"
+
+
+def test_filesystem_root_is_rejected(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    environment["INTERPRETER_HOME"] = "/"
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 1
+    assert "filesystem root" in result.stdout
+    assert not command_log.exists()
+    assert not _pointer(home).exists()
+
+
+def test_upgrade_reuses_recorded_location(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    root_posix = _posix(root)
+    _create_file(_pointer(home), root_posix)
+    _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    assert f"tool install --upgrade --python 3.12 --cache-dir {root_posix}/uv-cache interpreter-v2" in lines
+    assert not any(line.startswith("tool uninstall") for line in lines)
+    assert (root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg").exists()
+    assert _pointer(home).read_text(encoding="utf-8") == root_posix
+
+
+def test_moving_from_home_removes_previous_environment(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    default_environment = home / ".local" / "share" / "uv" / "tools" / "interpreter-v2"
+    _create_file(default_environment / "pyvenv.cfg")
+    root = tmp_path / "other-drive" / "interpreter"
+    environment["INTERPRETER_HOME"] = _posix(root)
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={_posix(home)}/.local/share/uv/tools"
+    assert uninstall_index < lines.index(next(line for line in lines if line.startswith("tool install")))
+    assert not default_environment.exists()
+    assert "remain in the HuggingFace cache" in result.stdout
+
+
+def test_moving_between_custom_locations_removes_previous_environment(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    old_root = tmp_path / "old-drive" / "interpreter"
+    new_root = tmp_path / "new-drive" / "interpreter"
+    _create_file(_pointer(home), _posix(old_root))
+    _create_file(old_root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+    _create_file(old_root / "models" / MODEL_CACHE_NAMES[0] / "blobs" / "model.bin")
+    environment["INTERPRETER_HOME"] = _posix(new_root)
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={_posix(old_root)}/uv/tools"
+    assert not (old_root / "uv" / "tools" / "interpreter-v2").exists()
+    # Models are never deleted by the installer; the user is told where they are.
+    assert (old_root / "models" / MODEL_CACHE_NAMES[0]).exists()
+    assert f"remain in {_posix(old_root)}/models" in result.stdout
+    assert _pointer(home).read_text(encoding="utf-8") == _posix(new_root)
+
+
+def test_failed_install_cleans_cache_and_records_nothing(tmp_path: Path) -> None:
+    environment, home, _, command_log = _environment(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    environment["INTERPRETER_HOME"] = _posix(root)
+    environment["UV_TEST_INSTALL_EXIT"] = "42"
+    _create_file(root / "uv-cache" / "partial-download.whl")
+
+    result = _run(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 1
+    assert "Installation failed" in result.stdout
+    assert f"cache clean --cache-dir {_posix(root)}/uv-cache" in _log_lines(command_log)
+    assert not (root / "uv-cache").exists()
+    assert not _pointer(home).exists()
+
+
+# --- uninstall.sh -------------------------------------------------------------
+
+
+def _populate_install(root: Path, home: Path, model_hub: Path) -> Path:
+    _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+    _create_file(root / "uv" / "python" / "cpython-3.12" / "bin" / "python")
+    _create_file(root / "uv-cache" / "partial-download.whl")
+    for model_cache_name in MODEL_CACHE_NAMES:
+        _create_file(root / "models" / model_cache_name / "blobs" / "model.bin")
+    _create_file(home / ".interpreter" / "config.yml")
+    # A model left in the default cache by an install that was later moved.
+    _create_file(model_hub / MODEL_CACHE_NAMES[2] / "blobs" / "model.bin")
+    unrelated_model = model_hub / "models--someone-else--unrelated"
+    _create_file(unrelated_model / "blobs" / "model.bin")
+    return unrelated_model
+
+
+def test_uninstall_removes_recorded_location(tmp_path: Path) -> None:
+    environment, home, model_hub, command_log = _environment(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    unrelated_model = _populate_install(root, home, model_hub)
+    _create_file(_pointer(home), _posix(root))
+
+    result = _run(UNINSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={_posix(root)}/uv/tools"
+    assert not root.exists()
+    assert not (home / ".interpreter").exists()
+    assert not (model_hub / MODEL_CACHE_NAMES[2]).exists()
+    assert unrelated_model.exists()
+    assert f"Removed install location {_posix(root)}" in result.stdout
+
+
+def test_uninstall_keeps_location_with_other_files_and_works_without_uv(tmp_path: Path) -> None:
+    environment, home, model_hub, command_log = _environment(tmp_path, with_uv=False)
+    root = tmp_path / "other-drive" / "interpreter"
+    _populate_install(root, home, model_hub)
+    _create_file(root / "my-notes.txt", "keep me")
+    environment["INTERPRETER_HOME"] = _posix(root)
+
+    result = _run(UNINSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not command_log.exists()
+    assert "uv was not found" in result.stdout
+    assert not (root / "uv").exists()
+    assert not (root / "uv-cache").exists()
+    assert not (root / "models").exists()
+    assert (root / "my-notes.txt").read_text(encoding="utf-8") == "keep me"
+    assert "Kept" in result.stdout
+    assert not (home / ".interpreter").exists()
+
+
+def test_uninstall_without_custom_location_removes_default_models(tmp_path: Path) -> None:
+    environment, home, model_hub, command_log = _environment(tmp_path)
+    _create_file(home / ".interpreter" / "config.yml")
+    for model_cache_name in MODEL_CACHE_NAMES:
+        _create_file(model_hub / model_cache_name / "blobs" / "model.bin")
+        _create_file(model_hub / ".locks" / model_cache_name / "download.lock")
+    legacy_model = model_hub / "models--bquenin--legacy-model"
+    _create_file(legacy_model / "blobs" / "model.bin")
+    unrelated_model = model_hub / "models--someone-else--unrelated"
+    _create_file(unrelated_model / "blobs" / "model.bin")
+
+    result = _run(UNINSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "tool uninstall interpreter-v2" in _log_lines(command_log)
+    for model_cache_name in MODEL_CACHE_NAMES:
+        assert not (model_hub / model_cache_name).exists()
+        assert not (model_hub / ".locks" / model_cache_name).exists()
+    assert not legacy_model.exists()
+    assert unrelated_model.exists()
+    assert not (home / ".interpreter").exists()
+    assert "No custom install location" in result.stdout

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -90,6 +90,19 @@ def test_tilde_is_expanded(home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert paths.get_install_root() == home / "interpreter"
 
 
+def test_relative_value_is_anchored_to_working_directory(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, "relative/interpreter/")
+
+    root = paths.get_install_root()
+
+    assert root is not None
+    assert root.is_absolute()
+    assert root == tmp_path / "relative" / "interpreter"
+
+
 def test_apply_environment_redirects_hf_cache(home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = tmp_path / "other-drive" / "interpreter"
     monkeypatch.setenv(paths.INSTALL_ROOT_ENV, str(root))

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,115 @@
+"""Tests for the custom install location resolution."""
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the module from its file so these tests run without the package being
+# installed (interpreter/__init__ reads the distribution version on import).
+_PATHS_FILE = Path(__file__).resolve().parents[1] / "src" / "interpreter" / "paths.py"
+_spec = importlib.util.spec_from_file_location("interpreter_paths_under_test", _PATHS_FILE)
+paths = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = paths
+_spec.loader.exec_module(paths)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    # Path.home() reads USERPROFILE on Windows and HOME elsewhere.
+    monkeypatch.setenv("USERPROFILE", str(home_dir))
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv(paths.INSTALL_ROOT_ENV, raising=False)
+    monkeypatch.delenv("HF_HUB_CACHE", raising=False)
+    return home_dir
+
+
+def _write_pointer(home_dir: Path, value: str) -> None:
+    config_dir = home_dir / ".interpreter"
+    config_dir.mkdir(exist_ok=True)
+    (config_dir / paths.INSTALL_ROOT_FILE_NAME).write_text(value, encoding="utf-8")
+
+
+def test_default_layout_when_nothing_is_configured(home: Path) -> None:
+    assert paths.get_install_root() is None
+    assert paths.get_models_dir() is None
+
+    paths.apply_environment()
+
+    assert "HF_HUB_CACHE" not in os.environ
+
+
+def test_environment_variable_sets_install_root(home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "other-drive" / "interpreter"
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, str(root))
+
+    assert paths.get_install_root() == root
+    assert paths.get_models_dir() == root / "models"
+
+
+def test_pointer_file_sets_install_root(home: Path, tmp_path: Path) -> None:
+    root = tmp_path / "other-drive" / "interpreter"
+    _write_pointer(home, f"{root}\n")
+
+    assert paths.get_install_root() == root
+    assert paths.get_models_dir() == root / "models"
+
+
+def test_environment_variable_wins_over_pointer_file(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pointer(home, str(tmp_path / "recorded"))
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, str(tmp_path / "explicit"))
+
+    assert paths.get_install_root() == tmp_path / "explicit"
+
+
+def test_blank_values_mean_default_layout(home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_pointer(home, "   \n")
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, "  ")
+
+    assert paths.get_install_root() is None
+
+
+def test_blank_environment_variable_falls_back_to_pointer(
+    home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_pointer(home, str(tmp_path / "recorded"))
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, "")
+
+    assert paths.get_install_root() == tmp_path / "recorded"
+
+
+def test_tilde_is_expanded(home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, "~/interpreter")
+
+    assert paths.get_install_root() == home / "interpreter"
+
+
+def test_apply_environment_redirects_hf_cache(home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "other-drive" / "interpreter"
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, str(root))
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "generic-hf-cache"))
+
+    paths.apply_environment()
+
+    assert os.environ["HF_HUB_CACHE"] == str(root / "models")
+
+
+def test_apply_environment_matches_huggingface_hub(home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """huggingface_hub reads HF_HUB_CACHE once at import; check it honors ours."""
+    pytest.importorskip("huggingface_hub")
+    root = tmp_path / "other-drive" / "interpreter"
+    monkeypatch.setenv(paths.INSTALL_ROOT_ENV, str(root))
+    monkeypatch.delitem(sys.modules, "huggingface_hub", raising=False)
+    monkeypatch.delitem(sys.modules, "huggingface_hub.constants", raising=False)
+
+    paths.apply_environment()
+    import huggingface_hub.constants as hf_constants
+
+    importlib_reloaded = importlib.reload(hf_constants)
+    assert Path(importlib_reloaded.HF_HUB_CACHE) == root / "models"

--- a/tests/test_uninstall_windows.py
+++ b/tests/test_uninstall_windows.py
@@ -288,6 +288,7 @@ def test_install_to_custom_location(tmp_path: Path) -> None:
     assert f"cache clean --cache-dir {root / 'uv-cache'}" in lines
     assert not any(line.startswith("tool uninstall") for line in lines)
     assert root.is_dir()
+    assert (root / ".interpreter-v2").is_file()
     assert not (root / "uv-cache").exists()
     assert not (local_app_data / "interpreter-v2").exists()
     assert _pointer(user_profile).read_text(encoding="utf-8") == str(root)
@@ -344,17 +345,17 @@ def test_moving_from_user_profile_removes_previous_environment(tmp_path: Path) -
 
     assert result.returncode == 0, result.stdout + result.stderr
     lines = _log_lines(command_log)
-    uninstall_index = lines.index("tool uninstall interpreter-v2")
-    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={app_data / 'uv' / 'tools'}"
     install_index = next(index for index, line in enumerate(lines) if line.startswith("tool install"))
-    assert uninstall_index < install_index
     assert lines[install_index + 1] == f"UV_TOOL_DIR={root / 'uv' / 'tools'}"
+    # The old environment is deleted directly: `uv tool uninstall` there would
+    # also remove the launcher the new install just created in the shared bin.
+    assert not any(line.startswith("tool uninstall") for line in lines)
     assert not default_environment.exists()
     assert "remain in the HuggingFace cache" in result.stdout
 
 
 def test_moving_between_custom_locations_removes_previous_environment(tmp_path: Path) -> None:
-    environment, user_profile, _, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    environment, user_profile, _, local_app_data, _, command_log = _environment_with_uv_stub(tmp_path)
     old_root = tmp_path / "old-drive" / "interpreter"
     new_root = tmp_path / "new-drive" / "interpreter"
     _create_file(_pointer(user_profile), str(old_root))
@@ -366,8 +367,8 @@ def test_moving_between_custom_locations_removes_previous_environment(tmp_path: 
 
     assert result.returncode == 0, result.stdout + result.stderr
     lines = _log_lines(command_log)
-    uninstall_index = lines.index("tool uninstall interpreter-v2")
-    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={old_root / 'uv' / 'tools'}"
+    assert _install_command(new_root, local_app_data) in lines
+    assert not any(line.startswith("tool uninstall") for line in lines)
     assert not (old_root / "uv" / "tools" / "interpreter-v2").exists()
     # Models are never deleted by the installer; the user is told where they are.
     assert (old_root / "models" / MODEL_CACHE_NAMES[0]).exists()
@@ -375,8 +376,10 @@ def test_moving_between_custom_locations_removes_previous_environment(tmp_path: 
     assert _pointer(user_profile).read_text(encoding="utf-8") == str(new_root)
 
 
-def test_failed_install_to_custom_location_cleans_cache_and_records_nothing(tmp_path: Path) -> None:
-    environment, user_profile, _, _, _, command_log = _environment_with_uv_stub(tmp_path)
+def test_failed_install_to_custom_location_keeps_previous_install(tmp_path: Path) -> None:
+    environment, user_profile, app_data, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    default_environment = app_data / "uv" / "tools" / "interpreter-v2"
+    _create_file(default_environment / "pyvenv.cfg")
     root = tmp_path / "other-drive" / "interpreter"
     environment["INTERPRETER_HOME"] = str(root)
     environment["UV_TEST_INSTALL_EXIT"] = "42"
@@ -388,10 +391,14 @@ def test_failed_install_to_custom_location_cleans_cache_and_records_nothing(tmp_
     assert "Installation failed" in result.stdout
     assert f"cache clean --cache-dir {root / 'uv-cache'}" in _log_lines(command_log)
     assert not (root / "uv-cache").exists()
+    # Nothing is recorded and the working installation is left untouched.
     assert not _pointer(user_profile).exists()
+    assert (default_environment / "pyvenv.cfg").exists()
 
 
-def _populate_custom_install(root: Path, user_profile: Path, model_hub: Path) -> Path:
+def _populate_custom_install(root: Path, user_profile: Path, model_hub: Path, *, marker: bool = True) -> Path:
+    if marker:
+        _create_file(root / ".interpreter-v2", "Created by the interpreter-v2 installer.")
     _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
     _create_file(root / "uv" / "python" / "cpython-3.12" / "python.exe")
     _create_file(root / "uv-cache" / "partial-download.whl")
@@ -447,3 +454,24 @@ def test_uninstall_keeps_location_with_other_files_and_works_without_uv(tmp_path
     assert (root / "my-notes.txt").read_text(encoding="utf-8") == "keep me"
     assert "Kept" in result.stdout
     assert not (user_profile / ".interpreter").exists()
+
+
+def test_uninstall_leaves_location_without_installer_marker_alone(tmp_path: Path) -> None:
+    """A mistyped or shared INTERPRETER_HOME must not have its contents deleted."""
+    environment, user_profile, _, _, model_hub, _ = _environment_with_uv_stub(tmp_path)
+    root = tmp_path / "shared-tools"
+    _populate_custom_install(root, user_profile, model_hub, marker=False)
+    _create_file(root / "uv" / "tools" / "other-tool" / "pyvenv.cfg")
+    environment["INTERPRETER_HOME"] = str(root)
+
+    result = _run_uninstaller(environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "was not created by the interpreter-v2 installer" in result.stdout
+    # Only interpreter-v2's own tool environment goes; everything else stays.
+    assert not (root / "uv" / "tools" / "interpreter-v2").exists()
+    assert (root / "uv" / "tools" / "other-tool" / "pyvenv.cfg").exists()
+    assert (root / "uv" / "python").exists()
+    assert (root / "uv-cache").exists()
+    for model_cache_name in MODEL_CACHE_NAMES:
+        assert (root / "models" / model_cache_name).exists()

--- a/tests/test_uninstall_windows.py
+++ b/tests/test_uninstall_windows.py
@@ -29,7 +29,9 @@ def _create_file(path: Path, content: str = "test") -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def _run_powershell_script(script: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_powershell_script(
+    script: Path, environment: dict[str, str], cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             POWERSHELL,
@@ -44,6 +46,7 @@ def _run_powershell_script(script: Path, environment: dict[str, str]) -> subproc
         check=False,
         capture_output=True,
         env=environment,
+        cwd=cwd,
         text=True,
         timeout=30,
     )
@@ -69,7 +72,9 @@ def _base_environment(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path,
         }
     )
     environment.pop("HF_HOME", None)
+    environment.pop("INTERPRETER_HOME", None)
     environment.pop("UV_CACHE_DIR", None)
+    environment.pop("UV_PYTHON_INSTALL_DIR", None)
     environment.pop("UV_TOOL_BIN_DIR", None)
     environment.pop("UV_TOOL_DIR", None)
     environment.pop("XDG_CACHE_HOME", None)
@@ -214,3 +219,231 @@ def test_cleans_files_and_models_when_uv_is_unavailable(tmp_path: Path, use_cust
     for model_cache_name in MODEL_CACHE_NAMES:
         assert not (model_hub / model_cache_name).exists()
     assert unrelated_model.exists()
+
+
+# --- Custom install location (INTERPRETER_HOME) -------------------------------
+
+# Records every call plus the uv directories it would use, and answers the
+# queries the scripts make. UV_TEST_INSTALL_EXIT makes `tool install` fail.
+UV_STUB_WITH_ENVIRONMENT = """@echo off
+echo %*>>"%UV_TEST_LOG%"
+echo UV_TOOL_DIR=%UV_TOOL_DIR%>>"%UV_TEST_LOG%"
+echo UV_PYTHON_INSTALL_DIR=%UV_PYTHON_INSTALL_DIR%>>"%UV_TEST_LOG%"
+if "%1 %2 %3"=="tool dir --bin" echo %UV_TOOL_BIN_DIR%
+if "%1 %2"=="tool dir" if not "%3"=="--bin" echo %UV_TOOL_DIR%
+if "%1 %2"=="tool list" echo interpreter-v2 v2.17.6
+if "%1 %2"=="tool install" if not "%UV_TEST_INSTALL_EXIT%"=="" exit /b %UV_TEST_INSTALL_EXIT%
+exit /b 0
+"""
+
+
+def _environment_with_uv_stub(tmp_path: Path) -> tuple[dict[str, str], Path, Path, Path, Path, Path]:
+    environment, user_profile, app_data, local_app_data, model_hub = _base_environment(tmp_path)
+    fake_bin = tmp_path / "fake-bin"
+    command_log = tmp_path / "uv-commands.log"
+    _create_file(fake_bin / "uv.cmd", UV_STUB_WITH_ENVIRONMENT)
+    environment.update({"PATH": str(fake_bin), "UV_TEST_LOG": str(command_log)})
+    return environment, user_profile, app_data, local_app_data, model_hub, command_log
+
+
+def _log_lines(command_log: Path) -> list[str]:
+    return command_log.read_text(encoding="utf-8").splitlines()
+
+
+def _pointer(user_profile: Path) -> Path:
+    return user_profile / ".interpreter" / "install-dir"
+
+
+def _install_command(root: Path | None, local_app_data: Path) -> str:
+    cache = root / "uv-cache" if root else local_app_data / "interpreter-v2" / "uv-cache"
+    return f"tool install --force --upgrade --python 3.12 --cache-dir {cache} interpreter-v2"
+
+
+def test_default_install_keeps_previous_behavior(tmp_path: Path) -> None:
+    environment, user_profile, _, local_app_data, _, command_log = _environment_with_uv_stub(tmp_path)
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    install_index = lines.index(_install_command(None, local_app_data))
+    assert lines[install_index + 1] == "UV_TOOL_DIR="
+    assert lines[install_index + 2] == "UV_PYTHON_INSTALL_DIR="
+    assert not _pointer(user_profile).exists()
+    assert "user profile" in result.stdout
+
+
+def test_install_to_custom_location(tmp_path: Path) -> None:
+    environment, user_profile, _, local_app_data, _, command_log = _environment_with_uv_stub(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    environment["INTERPRETER_HOME"] = str(root)
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    install_index = lines.index(_install_command(root, local_app_data))
+    assert lines[install_index + 1] == f"UV_TOOL_DIR={root / 'uv' / 'tools'}"
+    assert lines[install_index + 2] == f"UV_PYTHON_INSTALL_DIR={root / 'uv' / 'python'}"
+    assert f"cache clean --cache-dir {root / 'uv-cache'}" in lines
+    assert not any(line.startswith("tool uninstall") for line in lines)
+    assert root.is_dir()
+    assert not (root / "uv-cache").exists()
+    assert not (local_app_data / "interpreter-v2").exists()
+    assert _pointer(user_profile).read_text(encoding="utf-8") == str(root)
+    assert f"Installed to {root}" in result.stdout
+    assert str(root / "models") in result.stdout
+
+
+def test_relative_location_and_trailing_separator_are_normalized(tmp_path: Path) -> None:
+    environment, user_profile, _, _, _, _ = _environment_with_uv_stub(tmp_path)
+    environment["INTERPRETER_HOME"] = "relative\\interpreter\\"
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _pointer(user_profile).read_text(encoding="utf-8") == str(tmp_path / "relative" / "interpreter")
+
+
+def test_drive_root_is_rejected(tmp_path: Path) -> None:
+    environment, user_profile, _, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    environment["INTERPRETER_HOME"] = tmp_path.anchor  # e.g. C:\\
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 1
+    assert "drive root" in result.stdout
+    assert not command_log.exists()
+    assert not _pointer(user_profile).exists()
+
+
+def test_upgrade_reuses_recorded_location(tmp_path: Path) -> None:
+    environment, user_profile, _, local_app_data, _, command_log = _environment_with_uv_stub(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    _create_file(_pointer(user_profile), str(root))
+    _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    assert _install_command(root, local_app_data) in lines
+    assert not any(line.startswith("tool uninstall") for line in lines)
+    assert (root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg").exists()
+    assert _pointer(user_profile).read_text(encoding="utf-8") == str(root)
+
+
+def test_moving_from_user_profile_removes_previous_environment(tmp_path: Path) -> None:
+    environment, _, app_data, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    default_environment = app_data / "uv" / "tools" / "interpreter-v2"
+    _create_file(default_environment / "pyvenv.cfg")
+    root = tmp_path / "other-drive" / "interpreter"
+    environment["INTERPRETER_HOME"] = str(root)
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={app_data / 'uv' / 'tools'}"
+    install_index = next(index for index, line in enumerate(lines) if line.startswith("tool install"))
+    assert uninstall_index < install_index
+    assert lines[install_index + 1] == f"UV_TOOL_DIR={root / 'uv' / 'tools'}"
+    assert not default_environment.exists()
+    assert "remain in the HuggingFace cache" in result.stdout
+
+
+def test_moving_between_custom_locations_removes_previous_environment(tmp_path: Path) -> None:
+    environment, user_profile, _, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    old_root = tmp_path / "old-drive" / "interpreter"
+    new_root = tmp_path / "new-drive" / "interpreter"
+    _create_file(_pointer(user_profile), str(old_root))
+    _create_file(old_root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+    _create_file(old_root / "models" / MODEL_CACHE_NAMES[0] / "blobs" / "model.bin")
+    environment["INTERPRETER_HOME"] = str(new_root)
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={old_root / 'uv' / 'tools'}"
+    assert not (old_root / "uv" / "tools" / "interpreter-v2").exists()
+    # Models are never deleted by the installer; the user is told where they are.
+    assert (old_root / "models" / MODEL_CACHE_NAMES[0]).exists()
+    assert f"remain in {old_root / 'models'}" in result.stdout
+    assert _pointer(user_profile).read_text(encoding="utf-8") == str(new_root)
+
+
+def test_failed_install_to_custom_location_cleans_cache_and_records_nothing(tmp_path: Path) -> None:
+    environment, user_profile, _, _, _, command_log = _environment_with_uv_stub(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    environment["INTERPRETER_HOME"] = str(root)
+    environment["UV_TEST_INSTALL_EXIT"] = "42"
+    _create_file(root / "uv-cache" / "partial-download.whl")
+
+    result = _run_powershell_script(INSTALL_SCRIPT, environment)
+
+    assert result.returncode == 1
+    assert "Installation failed" in result.stdout
+    assert f"cache clean --cache-dir {root / 'uv-cache'}" in _log_lines(command_log)
+    assert not (root / "uv-cache").exists()
+    assert not _pointer(user_profile).exists()
+
+
+def _populate_custom_install(root: Path, user_profile: Path, model_hub: Path) -> Path:
+    _create_file(root / "uv" / "tools" / "interpreter-v2" / "pyvenv.cfg")
+    _create_file(root / "uv" / "python" / "cpython-3.12" / "python.exe")
+    _create_file(root / "uv-cache" / "partial-download.whl")
+    for model_cache_name in MODEL_CACHE_NAMES:
+        _create_file(root / "models" / model_cache_name / "blobs" / "model.bin")
+    _create_file(user_profile / ".interpreter" / "config.yml")
+    # A model left in the default cache by an install that was later moved.
+    _create_file(model_hub / MODEL_CACHE_NAMES[2] / "blobs" / "model.bin")
+    unrelated_model = model_hub / "models--someone-else--unrelated"
+    _create_file(unrelated_model / "blobs" / "model.bin")
+    return unrelated_model
+
+
+def test_uninstall_removes_recorded_location(tmp_path: Path) -> None:
+    environment, user_profile, app_data, _, model_hub, command_log = _environment_with_uv_stub(tmp_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    unrelated_model = _populate_custom_install(root, user_profile, model_hub)
+    _create_file(_pointer(user_profile), str(root))
+    leftover_default_environment = app_data / "uv" / "tools" / "interpreter-v2"
+    _create_file(leftover_default_environment / "pyvenv.cfg")
+
+    result = _run_uninstaller(environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    lines = _log_lines(command_log)
+    uninstall_index = lines.index("tool uninstall interpreter-v2")
+    assert lines[uninstall_index + 1] == f"UV_TOOL_DIR={root / 'uv' / 'tools'}"
+    assert not root.exists()
+    assert not leftover_default_environment.exists()
+    assert not (user_profile / ".interpreter").exists()
+    assert not (model_hub / MODEL_CACHE_NAMES[2]).exists()
+    assert unrelated_model.exists()
+    assert f"Removed install location {root}" in result.stdout
+
+
+def test_uninstall_keeps_location_with_other_files_and_works_without_uv(tmp_path: Path) -> None:
+    environment, user_profile, _, _, model_hub = _base_environment(tmp_path)
+    empty_path = tmp_path / "empty-path"
+    empty_path.mkdir()
+    environment["PATH"] = str(empty_path)
+    root = tmp_path / "other-drive" / "interpreter"
+    _populate_custom_install(root, user_profile, model_hub)
+    _create_file(root / "my-notes.txt", "keep me")
+    environment["INTERPRETER_HOME"] = str(root)
+
+    result = _run_uninstaller(environment)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "uv was not found" in result.stdout
+    assert not (root / "uv").exists()
+    assert not (root / "uv-cache").exists()
+    assert not (root / "models").exists()
+    assert (root / "my-notes.txt").read_text(encoding="utf-8") == "keep me"
+    assert "Kept" in result.stdout
+    assert not (user_profile / ".interpreter").exists()

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -27,6 +27,26 @@ function Remove-InterpreterPath {
     }
 }
 
+# A custom install location (see install.ps1) holds the tool environment, the
+# uv-managed Python, and the model cache. INTERPRETER_HOME wins over the pointer
+# file the installer wrote, matching the app and the installer.
+$configDir = Join-Path $env:USERPROFILE ".interpreter"
+$installRootFile = Join-Path $configDir "install-dir"
+$installRoot = $null
+if ($env:INTERPRETER_HOME -and $env:INTERPRETER_HOME.Trim()) {
+    $installRoot = $env:INTERPRETER_HOME.Trim()
+} elseif (Test-Path -LiteralPath $installRootFile -PathType Leaf) {
+    $installRoot = (Get-Content -LiteralPath $installRootFile -Raw).Trim()
+    if (-not $installRoot) { $installRoot = $null }
+}
+if ($installRoot) {
+    $installRoot = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($installRoot).TrimEnd('\')
+    $env:UV_TOOL_DIR = Join-Path $installRoot "uv\tools"
+    $env:UV_PYTHON_INSTALL_DIR = Join-Path $installRoot "uv\python"
+    Write-Host "Install location: $installRoot" -ForegroundColor Gray
+    Write-Host ""
+}
+
 # uv's installer adds itself to ~/.local/bin. Look there as a fallback because
 # the current shell may not have picked up the PATH change yet.
 $uvCommand = Get-Command uv -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -55,7 +75,7 @@ if ($uvExecutable) {
 $toolEnvironment = Join-Path $toolRoot "interpreter-v2"
 $toolExecutable = Join-Path $toolBin "interpreter-v2.exe"
 
-Write-Host "[1/4] Uninstalling interpreter-v2..." -ForegroundColor Yellow
+Write-Host "[1/5] Uninstalling interpreter-v2..." -ForegroundColor Yellow
 if ($uvExecutable) {
     $toolList = & $uvExecutable tool list 2>$null
     if ($toolList -match "interpreter-v2" -or (Test-Path -LiteralPath $toolEnvironment)) {
@@ -77,7 +97,7 @@ if ($uvExecutable) {
 }
 
 # Remove orphan files left by an interrupted install or a stale uv registry.
-Write-Host "[2/4] Cleaning up orphan files..." -ForegroundColor Yellow
+Write-Host "[2/5] Cleaning up orphan files..." -ForegroundColor Yellow
 if (Test-Path -LiteralPath $toolExecutable) {
     Remove-InterpreterPath -Path $toolExecutable -Description "orphan executable"
 } else {
@@ -88,14 +108,25 @@ if (Test-Path -LiteralPath $toolEnvironment) {
 } else {
     Write-Host "     No stale tool environment found" -ForegroundColor Gray
 }
+# An install that was later moved to a custom location may have left the
+# default environment behind.
+$defaultToolEnvironment = Join-Path $env:APPDATA "uv\tools\interpreter-v2"
+if ($installRoot -and (Test-Path -LiteralPath $defaultToolEnvironment)) {
+    Remove-InterpreterPath -Path $defaultToolEnvironment -Description "tool environment left in the user profile"
+}
 
 # New installers use this dedicated cache so it can always be removed without
 # disturbing other uv users. Older installers used uv's shared cache; prune only
 # entries uv knows are unreachable and leave reusable downloads alone.
-Write-Host "[3/4] Removing package downloads..." -ForegroundColor Yellow
-$installCacheDir = Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"
-if (Test-Path -LiteralPath $installCacheDir) {
-    Remove-InterpreterPath -Path $installCacheDir -Description "interpreter package cache"
+Write-Host "[3/5] Removing package downloads..." -ForegroundColor Yellow
+$installCacheDirs = @((Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"))
+if ($installRoot) {
+    $installCacheDirs += (Join-Path $installRoot "uv-cache")
+}
+foreach ($installCacheDir in $installCacheDirs) {
+    if (Test-Path -LiteralPath $installCacheDir) {
+        Remove-InterpreterPath -Path $installCacheDir -Description "interpreter package cache"
+    }
 }
 
 if ($uvExecutable) {
@@ -124,9 +155,8 @@ if ($uvExecutable) {
 }
 
 # Remove user data
-Write-Host "[4/4] Removing user data..." -ForegroundColor Yellow
+Write-Host "[4/5] Removing user data..." -ForegroundColor Yellow
 
-$configDir = Join-Path $env:USERPROFILE ".interpreter"
 if ($env:HF_HUB_CACHE) {
     $modelsDir = $env:HF_HUB_CACHE
 } elseif ($env:HF_HOME) {
@@ -145,7 +175,9 @@ if (Test-Path -LiteralPath $configDir) {
 }
 
 # Remove the repositories actually downloaded by interpreter-v2. Retain the
-# legacy bquenin pattern for caches created by older releases.
+# legacy bquenin pattern for caches created by older releases. With a custom
+# install location the models live under it and are removed below, but an
+# install that was moved there later may have left models in this cache.
 $modelCacheNames = @(
     "models--rtr46--meiki.text.detect.v0",
     "models--rtr46--meiki.txt.recognition.v0",
@@ -182,6 +214,25 @@ if (Test-Path -LiteralPath $modelsDir -PathType Container) {
 }
 if (-not $removedModel) {
     Write-Host "     Cached models not found" -ForegroundColor Gray
+}
+
+# Remove the custom install location. Only the folders the installer creates
+# are deleted, and the root itself only once it is empty, so a root shared with
+# other files (or pointed at the wrong place) is never wiped wholesale.
+Write-Host "[5/5] Removing install location..." -ForegroundColor Yellow
+if ($installRoot) {
+    Remove-InterpreterPath -Path (Join-Path $installRoot "uv") -Description "tool environment and Python"
+    Remove-InterpreterPath -Path (Join-Path $installRoot "models") -Description "downloaded models"
+    if (Test-Path -LiteralPath $installRoot -PathType Container) {
+        $leftovers = Get-ChildItem -LiteralPath $installRoot -Force -ErrorAction SilentlyContinue
+        if ($leftovers) {
+            Write-Host "     Kept $installRoot because it still contains other files" -ForegroundColor Gray
+        } else {
+            Remove-InterpreterPath -Path $installRoot -Description "install location $installRoot"
+        }
+    }
+} else {
+    Write-Host "     No custom install location" -ForegroundColor Gray
 }
 
 Write-Host ""

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -119,14 +119,9 @@ if ($installRoot -and (Test-Path -LiteralPath $defaultToolEnvironment)) {
 # disturbing other uv users. Older installers used uv's shared cache; prune only
 # entries uv knows are unreachable and leave reusable downloads alone.
 Write-Host "[3/5] Removing package downloads..." -ForegroundColor Yellow
-$installCacheDirs = @((Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"))
-if ($installRoot) {
-    $installCacheDirs += (Join-Path $installRoot "uv-cache")
-}
-foreach ($installCacheDir in $installCacheDirs) {
-    if (Test-Path -LiteralPath $installCacheDir) {
-        Remove-InterpreterPath -Path $installCacheDir -Description "interpreter package cache"
-    }
+$installCacheDir = Join-Path $env:LOCALAPPDATA "interpreter-v2\uv-cache"
+if (Test-Path -LiteralPath $installCacheDir) {
+    Remove-InterpreterPath -Path $installCacheDir -Description "interpreter package cache"
 }
 
 if ($uvExecutable) {
@@ -217,12 +212,20 @@ if (-not $removedModel) {
 }
 
 # Remove the custom install location. Only the folders the installer creates
-# are deleted, and the root itself only once it is empty, so a root shared with
-# other files (or pointed at the wrong place) is never wiped wholesale.
+# are deleted, only when the installer's marker file proves it created this
+# root, and the root itself only once it is empty. A mistyped INTERPRETER_HOME
+# or a root shared with other files is never wiped wholesale.
 Write-Host "[5/5] Removing install location..." -ForegroundColor Yellow
-if ($installRoot) {
+$installMarker = if ($installRoot) { Join-Path $installRoot ".interpreter-v2" } else { $null }
+if (-not $installRoot) {
+    Write-Host "     No custom install location" -ForegroundColor Gray
+} elseif (-not (Test-Path -LiteralPath $installMarker -PathType Leaf)) {
+    Write-Host "     $installRoot was not created by the interpreter-v2 installer; leaving it alone" -ForegroundColor Yellow
+} else {
     Remove-InterpreterPath -Path (Join-Path $installRoot "uv") -Description "tool environment and Python"
+    Remove-InterpreterPath -Path (Join-Path $installRoot "uv-cache") -Description "interpreter package cache"
     Remove-InterpreterPath -Path (Join-Path $installRoot "models") -Description "downloaded models"
+    Remove-Item -LiteralPath $installMarker -Force -ErrorAction SilentlyContinue
     if (Test-Path -LiteralPath $installRoot -PathType Container) {
         $leftovers = Get-ChildItem -LiteralPath $installRoot -Force -ErrorAction SilentlyContinue
         if ($leftovers) {
@@ -231,8 +234,6 @@ if ($installRoot) {
             Remove-InterpreterPath -Path $installRoot -Description "install location $installRoot"
         }
     }
-} else {
-    Write-Host "     No custom install location" -ForegroundColor Gray
 }
 
 Write-Host ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,24 +16,65 @@ echo ""
 echo -e "${CYAN}=== interpreter-v2 Uninstaller ===${NC}"
 echo ""
 
-# Check if uv is installed
-if ! command -v uv &>/dev/null; then
-	echo -e "${YELLOW}uv is not installed. Nothing to uninstall.${NC}"
-	exit 0
+# A custom install location (see install.sh) holds the tool environment, the
+# uv-managed Python, and the model cache. INTERPRETER_HOME wins over the pointer
+# file the installer wrote, matching the app and the installer.
+CONFIG_DIR="$HOME/.interpreter"
+INSTALL_ROOT_FILE="$CONFIG_DIR/install-dir"
+INSTALL_ROOT="${INTERPRETER_HOME:-}"
+if [ -z "$INSTALL_ROOT" ] && [ -f "$INSTALL_ROOT_FILE" ]; then
+	INSTALL_ROOT=$(tr -d '\r\n' <"$INSTALL_ROOT_FILE")
+fi
+if [ -n "$INSTALL_ROOT" ]; then
+	INSTALL_ROOT="${INSTALL_ROOT/#\~/$HOME}"
+	case "$INSTALL_ROOT" in
+	/*) ;;
+	*) INSTALL_ROOT="$PWD/$INSTALL_ROOT" ;;
+	esac
+	INSTALL_ROOT="${INSTALL_ROOT%/}"
+fi
+if [ -n "$INSTALL_ROOT" ]; then
+	export UV_TOOL_DIR="$INSTALL_ROOT/uv/tools"
+	export UV_PYTHON_INSTALL_DIR="$INSTALL_ROOT/uv/python"
+	echo -e "${GRAY}Install location: $INSTALL_ROOT${NC}"
+	echo ""
 fi
 
-# Check if interpreter-v2 is installed
-if ! uv tool list 2>/dev/null | grep -q "interpreter-v2"; then
-	echo -e "${YELLOW}interpreter-v2 is not installed.${NC}"
+# Uninstall the tool. Without uv, fall back to removing its files directly.
+echo -e "${YELLOW}[1/4] Uninstalling interpreter-v2...${NC}"
+TOOL_ROOT="${UV_TOOL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools}"
+if command -v uv &>/dev/null; then
+	REPORTED_TOOL_ROOT=$(uv tool dir 2>/dev/null || true)
+	if [ -n "$REPORTED_TOOL_ROOT" ]; then
+		TOOL_ROOT="$REPORTED_TOOL_ROOT"
+	fi
+	if uv tool list 2>/dev/null | grep -q "interpreter-v2"; then
+		uv tool uninstall interpreter-v2
+		echo -e "${GREEN}     interpreter-v2 uninstalled${NC}"
+	else
+		echo -e "${GRAY}     interpreter-v2 is not registered with uv${NC}"
+	fi
 else
-	echo -e "${YELLOW}[1/3] Uninstalling interpreter-v2...${NC}"
-	uv tool uninstall interpreter-v2
-	echo -e "${GREEN}interpreter-v2 uninstalled${NC}"
+	echo -e "${YELLOW}     uv was not found; cleaning up its files directly${NC}"
+fi
+if [ -d "$TOOL_ROOT/interpreter-v2" ]; then
+	rm -rf "$TOOL_ROOT/interpreter-v2"
+	echo -e "${GREEN}     Removed stale tool environment${NC}"
+fi
+if [ -n "$INSTALL_ROOT" ]; then
+	# An install that was later moved to a custom location may have left the
+	# default environment and its package downloads behind.
+	DEFAULT_TOOL_ENV="${XDG_DATA_HOME:-$HOME/.local/share}/uv/tools/interpreter-v2"
+	if [ -d "$DEFAULT_TOOL_ENV" ]; then
+		rm -rf "$DEFAULT_TOOL_ENV"
+		echo -e "${GREEN}     Removed tool environment left in the home directory${NC}"
+	fi
+	rm -rf "$INSTALL_ROOT/uv-cache"
 fi
 
 # Remove desktop entry and icon (Linux only)
 if [[ "$(uname)" == "Linux" ]]; then
-	echo -e "${YELLOW}[2/3] Removing desktop entry and icon...${NC}"
+	echo -e "${YELLOW}[2/4] Removing desktop entry and icon...${NC}"
 
 	DESKTOP_FILE="$HOME/.local/share/applications/interpreter-v2.desktop"
 	ICON_FILE="$HOME/.local/share/icons/hicolor/256x256/apps/interpreter-v2.png"
@@ -60,16 +101,21 @@ if [[ "$(uname)" == "Linux" ]]; then
 	# Update desktop database
 	update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
 else
-	echo -e "${GRAY}[2/3] Skipping desktop entry removal (not Linux)${NC}"
+	echo -e "${GRAY}[2/4] Skipping desktop entry removal (not Linux)${NC}"
 fi
 
 # Remove user data
-echo -e "${YELLOW}[3/3] Removing user data...${NC}"
+echo -e "${YELLOW}[3/4] Removing user data...${NC}"
 
-CONFIG_DIR="$HOME/.interpreter"
-MODELS_DIR="$HOME/.cache/huggingface/hub"
+if [ -n "${HF_HUB_CACHE:-}" ]; then
+	MODELS_DIR="$HF_HUB_CACHE"
+elif [ -n "${HF_HOME:-}" ]; then
+	MODELS_DIR="$HF_HOME/hub"
+else
+	MODELS_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/huggingface/hub"
+fi
 
-# Remove config
+# Remove config (this also removes the install location pointer)
 if [ -d "$CONFIG_DIR" ]; then
 	rm -rf "$CONFIG_DIR"
 	echo -e "${GREEN}     Removed config directory${NC}"
@@ -77,15 +123,58 @@ else
 	echo -e "${GRAY}     Config directory not found${NC}"
 fi
 
-# Remove cached models
-INTERPRETER_MODELS=$(find "$MODELS_DIR" -maxdepth 1 -type d -name "models--bquenin--*" 2>/dev/null || true)
-if [ -n "$INTERPRETER_MODELS" ]; then
-	echo "$INTERPRETER_MODELS" | while read -r model; do
-		rm -rf "$model"
-		echo -e "${GREEN}     Removed $(basename "$model")${NC}"
+# Remove the repositories actually downloaded by interpreter-v2. Retain the
+# legacy bquenin pattern for caches created by older releases. With a custom
+# install location the models live under it and are removed below, but an
+# install that was moved there later may have left models in this cache.
+REMOVED_MODEL=0
+if [ -d "$MODELS_DIR" ]; then
+	for MODEL_NAME in \
+		"models--rtr46--meiki.text.detect.v0" \
+		"models--rtr46--meiki.txt.recognition.v0" \
+		"models--entai2965--sugoi-v4-ja-en-ctranslate2"; do
+		if [ -d "$MODELS_DIR/$MODEL_NAME" ]; then
+			rm -rf "$MODELS_DIR/$MODEL_NAME"
+			echo -e "${GREEN}     Removed $MODEL_NAME${NC}"
+			REMOVED_MODEL=1
+		fi
+		rm -rf "$MODELS_DIR/.locks/$MODEL_NAME"
 	done
-else
+	LEGACY_MODELS=$(find "$MODELS_DIR" -maxdepth 1 -type d -name "models--bquenin--*" 2>/dev/null || true)
+	if [ -n "$LEGACY_MODELS" ]; then
+		echo "$LEGACY_MODELS" | while read -r model; do
+			rm -rf "$model" "$MODELS_DIR/.locks/$(basename "$model")"
+			echo -e "${GREEN}     Removed $(basename "$model")${NC}"
+		done
+		REMOVED_MODEL=1
+	fi
+fi
+if [ "$REMOVED_MODEL" -eq 0 ]; then
 	echo -e "${GRAY}     Cached models not found${NC}"
+fi
+
+# Remove the custom install location. Only the folders the installer creates
+# are deleted, and the root itself only once it is empty, so a root shared with
+# other files (or pointed at the wrong place) is never wiped wholesale.
+echo -e "${YELLOW}[4/4] Removing install location...${NC}"
+if [ -n "$INSTALL_ROOT" ]; then
+	if [ -d "$INSTALL_ROOT/uv" ]; then
+		rm -rf "$INSTALL_ROOT/uv"
+		echo -e "${GREEN}     Removed tool environment and Python${NC}"
+	fi
+	if [ -d "$INSTALL_ROOT/models" ]; then
+		rm -rf "$INSTALL_ROOT/models"
+		echo -e "${GREEN}     Removed downloaded models${NC}"
+	fi
+	if [ -d "$INSTALL_ROOT" ]; then
+		if rmdir "$INSTALL_ROOT" 2>/dev/null; then
+			echo -e "${GREEN}     Removed install location $INSTALL_ROOT${NC}"
+		else
+			echo -e "${GRAY}     Kept $INSTALL_ROOT because it still contains other files${NC}"
+		fi
+	fi
+else
+	echo -e "${GRAY}     No custom install location${NC}"
 fi
 
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -69,7 +69,6 @@ if [ -n "$INSTALL_ROOT" ]; then
 		rm -rf "$DEFAULT_TOOL_ENV"
 		echo -e "${GREEN}     Removed tool environment left in the home directory${NC}"
 	fi
-	rm -rf "$INSTALL_ROOT/uv-cache"
 fi
 
 # Remove desktop entry and icon (Linux only)
@@ -154,27 +153,33 @@ if [ "$REMOVED_MODEL" -eq 0 ]; then
 fi
 
 # Remove the custom install location. Only the folders the installer creates
-# are deleted, and the root itself only once it is empty, so a root shared with
-# other files (or pointed at the wrong place) is never wiped wholesale.
+# are deleted, only when the installer's marker file proves it created this
+# root, and the root itself only once it is empty. A mistyped INTERPRETER_HOME
+# or a root shared with other files is never wiped wholesale.
 echo -e "${YELLOW}[4/4] Removing install location...${NC}"
-if [ -n "$INSTALL_ROOT" ]; then
+if [ -z "$INSTALL_ROOT" ]; then
+	echo -e "${GRAY}     No custom install location${NC}"
+elif [ ! -f "$INSTALL_ROOT/.interpreter-v2" ]; then
+	echo -e "${YELLOW}     $INSTALL_ROOT was not created by the interpreter-v2 installer; leaving it alone${NC}"
+else
 	if [ -d "$INSTALL_ROOT/uv" ]; then
 		rm -rf "$INSTALL_ROOT/uv"
 		echo -e "${GREEN}     Removed tool environment and Python${NC}"
+	fi
+	if [ -d "$INSTALL_ROOT/uv-cache" ]; then
+		rm -rf "$INSTALL_ROOT/uv-cache"
+		echo -e "${GREEN}     Removed interpreter package cache${NC}"
 	fi
 	if [ -d "$INSTALL_ROOT/models" ]; then
 		rm -rf "$INSTALL_ROOT/models"
 		echo -e "${GREEN}     Removed downloaded models${NC}"
 	fi
-	if [ -d "$INSTALL_ROOT" ]; then
-		if rmdir "$INSTALL_ROOT" 2>/dev/null; then
-			echo -e "${GREEN}     Removed install location $INSTALL_ROOT${NC}"
-		else
-			echo -e "${GRAY}     Kept $INSTALL_ROOT because it still contains other files${NC}"
-		fi
+	rm -f "$INSTALL_ROOT/.interpreter-v2"
+	if rmdir "$INSTALL_ROOT" 2>/dev/null; then
+		echo -e "${GREEN}     Removed install location $INSTALL_ROOT${NC}"
+	else
+		echo -e "${GRAY}     Kept $INSTALL_ROOT because it still contains other files${NC}"
 	fi
-else
-	echo -e "${GRAY}     No custom install location${NC}"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #239

## Summary

Users with a small system drive can set `INTERPRETER_HOME` before running the one-liner installer to put everything on another drive:

```powershell
$env:INTERPRETER_HOME = "D:\interpreter"; powershell -c "irm https://raw.githubusercontent.com/bquenin/interpreter/main/install.ps1 | iex"
```

```bash
INTERPRETER_HOME=/mnt/data/interpreter curl -LsSf https://raw.githubusercontent.com/bquenin/interpreter/main/install.sh | bash
```

The uv tool environment, the uv-managed Python, the package downloads, and the HuggingFace model cache all go under that folder. The location is recorded in `~/.interpreter/install-dir`, so later plain re-runs upgrade in place, the app redirects model downloads there, and the uninstaller removes it. Only the launcher and `config.yml` stay in the profile. The default install is unchanged.

## Changes

- New `interpreter.paths` resolves the location (env var, then pointer file) and sets `HF_HUB_CACHE` before `huggingface_hub` is imported; `main()` calls it first.
- Both installers export `UV_TOOL_DIR` and `UV_PYTHON_INSTALL_DIR`, keep the install cache under the root, reject drive/filesystem roots, normalize relative and `~` paths, write the pointer without a BOM, and remove the tool environment from the previous location when it changes (with a note about where old models remain).
- Both uninstallers set the uv directories from the location, delete only the folders the installer creates, and remove the root only once empty. `uninstall.sh` also learns the current model names and the `HF_HUB_CACHE`/`HF_HOME`/`XDG_CACHE_HOME` handling the Windows uninstaller already had.
- README section "Installing to a Different Location" covers first install, changing the location, and going back to the default.
- CI runs the new bash-script tests on Ubuntu as well as Windows.

## Testing

- `tests/test_paths.py` (9), `tests/test_uninstall_windows.py` (15, 11 new), `tests/test_install_scripts_posix.py` (10, new): all pass locally on Windows, the bash tests via Git Bash.
- Real end-to-end run with a sandboxed profile: `install.ps1` installed 2.9 GB into `C:\interpreter-e2e\root` in 90 s and cleaned its cache; the installed venv running this branch downloaded a model into `<root>\models`; `uninstall.ps1` found the location from the pointer file and removed the root, config, and launcher, leaving uv with no tools. A separate `uv python install` confirmed the Python redirect (uv had reused the system 3.12 during the install).

## Notes

- Models only follow the custom location once a release containing `paths.py` is on PyPI; the installer side works independently.
- Existing default installs are not migrated automatically. Re-running the installer with the variable set relocates the application and reports where the old models are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
