### PR TITLE
Support source languages other than Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Use `127.0.0.1`, not `localhost`: on Windows, `localhost` adds about two seconds
 - **Speed**: on an RTX 4070 Ti, Sugoi 14B Ultra answers in about 300 ms per line (1.2 s at p95) and `gemma3:4b` in about 100 ms. CPU-only machines take seconds per line, which is fine for dialogue and painful for menus. The fuzzy translation cache still avoids re-translating text that has not changed. Keep only one large model in use at a time: two 8 GB models on a 12 GB card evict each other on every request.
 - **Quality**: larger models keep names and tone more consistent, and the previous few lines are sent as context. They also know many games and may use the official localized names instead of a literal translation. Edit the **Prompt** if you want different behaviour.
 - **Reasoning models** (Qwen3 and friends): thinking is turned off automatically on Ollama. Other servers each have their own switch, so set it through `request_options` in `config.yml`; the fields are merged into every request, for example `request_options: {reasoning_effort: none}`. Stripping inline `<think>` blocks from the reply is only a fallback and does not save the thinking time. If a server rejects an option, the **Test** button shows its error.
-- **Target language**: the LLM engine can translate into any language the model handles. OCR is still Japanese only.
+- **Target language**: the LLM engine can translate into any language the model handles. For games that are not in Japanese, see *Games in Other Languages* below.
 - **Remote endpoints**: the API key is stored in plain text in `config.yml`, every line of game text leaves your machine, and each request may cost money. Nothing is sent anywhere unless you pick the LLM engine.
 
 The same settings live in `config.yml` under `translation_backend` and `llm` if you prefer editing them by hand.
@@ -156,9 +156,18 @@ MeikiOCR is the built-in default and needs no setup. If it struggles with a part
 - **Errors**: if owocr stops or is paused, the OCR status turns to *Error* after three failed frames. Start owocr again and click **Fix Models** to reconnect.
 - **One client at a time**: owocr broadcasts every result to every connected client, so run a dedicated owocr instance for Interpreter. owocr also listens on all network interfaces; keep port 7331 firewalled.
 - **Remote owocr**: owocr speaks plain `ws://`, so pointing Interpreter at another machine sends every screen capture unencrypted over the network. Interpreter warns when the address is not local. On an untrusted network put a TLS proxy in front of owocr and use a `wss://` URL.
-- **Languages**: translation is still limited to Japanese text in this version, whichever OCR engine reads it.
+- **Languages**: with owocr selected, the **Source language** dropdown in the OCR group unlocks. See *Games in Other Languages* below.
 
 The same settings live in `config.yml` under `ocr_backend` and `owocr`.
+
+## Games in Other Languages
+
+Interpreter can read and translate games in Chinese, Korean, English, French, German, Spanish, Italian, Portuguese and Russian, not only Japanese. The built-in engines cannot: MeikiOCR reads Japanese only and Sugoi V4 translates Japanese to English only. So a non-Japanese game needs both alternative engines:
+
+1. Run owocr with an engine that reads the script (Google Lens, Bing, OneOCR and Apple Live Text all do; see *Using a Different OCR Engine*). In the **OCR** group pick *owocr*, then choose the **Source language**. The dropdown is locked to Japanese while MeikiOCR is selected.
+2. In the **Translation** group pick *LLM endpoint* with a model that knows the language, set the **Target language**, click **Test** (it translates a sample line in the source language) and **Apply**.
+
+Apply refuses the combination of a non-Japanese source with Sugoi V4, and says so. The source language is also used to filter OCR noise: only regions that contain characters from that language's script are translated. The setting lives in `config.yml` as `source_language`.
 
 ## Troubleshooting
 

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import yaml
 
 from . import log
+from .languages import DEFAULT_SOURCE_LANGUAGE, SOURCE_LANGUAGES, normalize_source_language
 
 
 class OverlayMode(str, Enum):
@@ -183,12 +184,14 @@ class Config:
         llm: LLMSettings | None = None,
         ocr_backend: OCRBackend = OCRBackend.MEIKI,
         owocr: OwocrSettings | None = None,
+        source_language: str = DEFAULT_SOURCE_LANGUAGE,
     ):
         self.window_title = window_title
         self.translation_backend = translation_backend
         self.llm = llm if llm is not None else LLMSettings()
         self.ocr_backend = ocr_backend
         self.owocr = owocr if owocr is not None else OwocrSettings()
+        self.source_language = source_language  # language of the game's text, see languages.SOURCE_LANGUAGES
         self.ocr_confidence = ocr_confidence  # Global default
         self.overlay_mode = overlay_mode
         self.font_family = font_family  # None = system default
@@ -261,6 +264,15 @@ class Config:
                 logger.warning("invalid ocr_backend, using meiki", backend=ocr_backend_str)
                 ocr_backend = OCRBackend.MEIKI
 
+            source_language_str = data.get("source_language", DEFAULT_SOURCE_LANGUAGE)
+            source_language = normalize_source_language(source_language_str)
+            if source_language.lower() != str(source_language_str).strip().lower():
+                logger.warning(
+                    "unsupported source_language, using default",
+                    value=source_language_str,
+                    supported=", ".join(SOURCE_LANGUAGES),
+                )
+
             return cls(
                 window_title=data.get("window_title", cls.DEFAULT_WINDOW_TITLE),
                 ocr_confidence=float(data.get("ocr_confidence", cls.DEFAULT_OCR_CONFIDENCE)),
@@ -280,6 +292,7 @@ class Config:
                 llm=LLMSettings.from_dict(data.get("llm")),
                 ocr_backend=ocr_backend,
                 owocr=OwocrSettings.from_dict(data.get("owocr")),
+                source_language=source_language,
             )
 
         # No config file found - create default in home directory
@@ -337,6 +350,11 @@ background_opacity: 0.8  # 0.0 (transparent) to 1.0 (opaque)
 # owocr:
 #   url: ws://127.0.0.1:7331
 #   timeout: 10                 # seconds to wait for each frame's result
+
+# Language of the game's text. MeikiOCR and Sugoi V4 only handle Japanese; other languages
+# need the owocr OCR engine and the LLM translation engine. One of: Japanese, Chinese, Korean,
+# English, French, German, Spanish, Italian, Portuguese, Russian
+source_language: Japanese
 
 # Hotkeys - single characters or special key names
 # Special keys: f1-f12, escape, space, enter, tab, backspace, delete,
@@ -446,6 +464,7 @@ hotkeys:
         data["ocr_backend"] = self.ocr_backend.value
         if self.ocr_backend == OCRBackend.OWOCR or self.owocr != OwocrSettings():
             data["owocr"] = self.owocr.to_dict()
+        data["source_language"] = str(self.source_language)
         # Only save font_family if user has chosen one (None = system default)
         if self.font_family is not None:
             data["font_family"] = str(self.font_family)
@@ -458,17 +477,12 @@ hotkeys:
         # Convert keys to plain strings to avoid Python-specific YAML tags
         if self.exclusion_zones:
             data["exclusion_zones"] = {
-                str(k): [
-                    {str(zk): float(zv) for zk, zv in zone.items()}
-                    for zone in zones
-                ]
+                str(k): [{str(zk): float(zv) for zk, zv in zone.items()} for zone in zones]
                 for k, zones in self.exclusion_zones.items()
             }
         # Save per-window OCR confidence if any are defined
         if self.ocr_confidence_per_window:
-            data["ocr_confidence_per_window"] = {
-                str(k): float(v) for k, v in self.ocr_confidence_per_window.items()
-            }
+            data["ocr_confidence_per_window"] = {str(k): float(v) for k, v in self.ocr_confidence_per_window.items()}
 
         with open(config_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, allow_unicode=True)

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -1037,7 +1037,12 @@ class MainWindow(QMainWindow):
             delete_model_cache("rtr46/meiki.text.detect.v0")
             delete_model_cache("rtr46/meiki.txt.recognition.v0")
             self._fixing_ocr = True
-        if "translation" in failed and self._config.translation_backend == TranslationBackend.SUGOI:
+        if (
+            "translation" in failed
+            and self._config.translation_backend == TranslationBackend.SUGOI
+            # A source-language conflict is a settings problem, not a corrupt download
+            and self._config.source_language == SUGOI_SOURCE_LANGUAGE
+        ):
             delete_model_cache("entai2965/sugoi-v4-ja-en-ctranslate2")
             self._fixing_translation = True
 

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -116,6 +116,7 @@ class MainWindow(QMainWindow):
         # Settings snapshots of the in-flight Refresh / Test requests (stale results are dropped)
         self._llm_refresh_request: LLMSettings | None = None
         self._llm_test_request: LLMSettings | None = None
+        self._llm_test_language: str = self._config.source_language
         self._owocr_test_request: OwocrSettings | None = None
 
         # Overlays
@@ -807,10 +808,13 @@ class MainWindow(QMainWindow):
         if not settings.model:
             self._set_llm_result("Pick a model first.", error=True)
             return
+        # The source language the OCR group would apply, not the saved one: the Test must
+        # validate what the user is about to Apply, like every other pending field
+        source_language = self._selected_source_language()
         self._llm_test_request = settings
-        source_language = self._config.source_language
+        self._llm_test_language = source_language
         self._llm_test_btn.setEnabled(False)
-        self._set_llm_result("Testing (loading the model may take a moment)...")
+        self._set_llm_result(f"Testing with a {source_language} sample (loading the model may take a moment)...")
 
         def run():
             try:
@@ -826,7 +830,7 @@ class MainWindow(QMainWindow):
             return  # superseded by a newer Test
         self._llm_test_request = None
         self._llm_test_btn.setEnabled(True)
-        if settings != self._llm_settings_from_ui():
+        if settings != self._llm_settings_from_ui() or self._llm_test_language != self._selected_source_language():
             self._set_llm_result("Settings changed during the test; click Test again.", error=True)
             return
         if isinstance(result, str):

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -30,6 +30,7 @@ from .. import log
 from ..capture import Capture, WindowCapture, _is_wayland_session
 from ..capture.convert import bgra_to_rgb_pil
 from ..config import Config, LLMSettings, OCRBackend, OverlayMode, OwocrSettings, TranslationBackend
+from ..languages import DEFAULT_SOURCE_LANGUAGE, SOURCE_LANGUAGES
 from ..llm_translate import (
     DEFAULT_BASE_URLS,
     DEFAULT_SYSTEM_PROMPT,
@@ -56,6 +57,7 @@ from ..permissions import (
     request_accessibility,
     request_screen_recording,
 )
+from ..translate import SUGOI_ONLY_JAPANESE, SUGOI_SOURCE_LANGUAGE
 from . import keyboard
 from .ocr_config import OCRConfigDialog
 from .workers import ProcessWorker
@@ -442,6 +444,23 @@ class MainWindow(QMainWindow):
         engine_row.addWidget(self._apply_ocr_btn)
         group_layout.addLayout(engine_row)
 
+        # Source language row: MeikiOCR reads Japanese only, so the choice is pinned for it
+        language_row = QHBoxLayout()
+        language_row.addWidget(QLabel("Source language:"))
+        self._source_language_combo = QComboBox()
+        for language in SOURCE_LANGUAGES:
+            self._source_language_combo.addItem(language, language)
+        self._source_language_combo.setCurrentIndex(
+            max(0, self._source_language_combo.findData(self._config.source_language))
+        )
+        self._source_language_combo.setToolTip(
+            "Language of the game's text. MeikiOCR and Sugoi V4 only handle Japanese; other languages "
+            "need the owocr OCR engine and the LLM endpoint translation engine."
+        )
+        language_row.addWidget(self._source_language_combo, 1)
+        group_layout.addLayout(language_row)
+        self._sync_source_language_combo()
+
         # owocr panel (only visible for the owocr engine)
         self._owocr_panel = QWidget()
         owocr_grid = QGridLayout(self._owocr_panel)
@@ -495,7 +514,21 @@ class MainWindow(QMainWindow):
     def _on_ocr_engine_changed(self, _index: int):
         """Show the owocr panel only when the owocr engine is selected."""
         self._owocr_panel.setVisible(self._selected_ocr_backend() == OCRBackend.OWOCR)
+        self._sync_source_language_combo()
         self._grow_to_fit()
+
+    def _sync_source_language_combo(self):
+        """Pin the source language to Japanese while MeikiOCR is selected; free it for owocr."""
+        pluggable = self._selected_ocr_backend() == OCRBackend.OWOCR
+        if not pluggable:
+            self._source_language_combo.setCurrentIndex(self._source_language_combo.findData(DEFAULT_SOURCE_LANGUAGE))
+        self._source_language_combo.setEnabled(pluggable)
+
+    def _selected_source_language(self) -> str:
+        """The source language the OCR group would apply (Japanese whenever MeikiOCR is selected)."""
+        if self._selected_ocr_backend() != OCRBackend.OWOCR:
+            return DEFAULT_SOURCE_LANGUAGE
+        return self._source_language_combo.currentData() or DEFAULT_SOURCE_LANGUAGE
 
     def _set_owocr_result(self, text: str, error: bool = False):
         self._set_result_label(self._owocr_result_label, text, error)
@@ -535,13 +568,20 @@ class MainWindow(QMainWindow):
     def _apply_ocr_settings(self):
         """Save the OCR group to config and reload the engine in the worker."""
         backend = self._selected_ocr_backend()
+        source_language = self._selected_source_language()
+        if source_language != SUGOI_SOURCE_LANGUAGE and self._config.translation_backend == TranslationBackend.SUGOI:
+            # The owocr panel is visible whenever a non-Japanese source can be selected
+            self._set_owocr_result(SUGOI_ONLY_JAPANESE, error=True)
+            return
         if backend == OCRBackend.OWOCR:
             self._config.owocr = self._owocr_settings_from_ui()
             self._owocr_url_edit.setText(self._config.owocr.url)
             # Stale results from a previous Test or failure would contradict the new status
             warning = owocr_remote_warning(self._config.owocr.url)
             self._set_owocr_result(warning or "", error=bool(warning))
+        language_changed = source_language != self._config.source_language
         self._config.ocr_backend = backend
+        self._config.source_language = source_language
         self._config.save()
 
         self._ocr_engine_label.setText(self._ocr_engine_name())
@@ -549,6 +589,9 @@ class MainWindow(QMainWindow):
         self._fix_models_btn.setVisible(False)
         self.statusBar().showMessage("Reloading OCR engine...")
         self._process_worker.reload_ocr()
+        if language_changed:
+            # The LLM prompt names the source language, so the translation engine follows
+            self._process_worker.reload_translation()
 
     # ==================== TRANSLATION SETTINGS ====================
 
@@ -621,7 +664,9 @@ class MainWindow(QMainWindow):
         llm_grid.addWidget(QLabel("Prompt:"), 3, 0, Qt.AlignmentFlag.AlignTop)
         self._llm_prompt_edit = QPlainTextEdit(settings.system_prompt or DEFAULT_SYSTEM_PROMPT)
         self._llm_prompt_edit.setFixedHeight(64)
-        self._llm_prompt_edit.setToolTip("System prompt sent to the model. {target_language} is replaced.")
+        self._llm_prompt_edit.setToolTip(
+            "System prompt sent to the model. {source_language} and {target_language} are replaced."
+        )
         llm_grid.addWidget(self._llm_prompt_edit, 3, 1, 1, 3)
         reset_prompt_btn = QPushButton("Reset")
         reset_prompt_btn.setToolTip("Restore the default prompt")
@@ -763,12 +808,13 @@ class MainWindow(QMainWindow):
             self._set_llm_result("Pick a model first.", error=True)
             return
         self._llm_test_request = settings
+        source_language = self._config.source_language
         self._llm_test_btn.setEnabled(False)
         self._set_llm_result("Testing (loading the model may take a moment)...")
 
         def run():
             try:
-                self._llm_test_result.emit((settings, check_endpoint(settings)))
+                self._llm_test_result.emit((settings, check_endpoint(settings, source_language)))
             except Exception as e:
                 self._llm_test_result.emit((settings, str(e)))
 
@@ -798,6 +844,11 @@ class MainWindow(QMainWindow):
                 self._set_llm_result("Pick a model before applying.", error=True)
                 return
             self._config.llm = settings
+        elif self._config.source_language != SUGOI_SOURCE_LANGUAGE:
+            # The LLM panel is hidden for Sugoi, so the refusal goes to the status row and bar
+            self._translation_status_label.setToolTip(SUGOI_ONLY_JAPANESE)
+            self.statusBar().showMessage(SUGOI_ONLY_JAPANESE)
+            return
         self._config.translation_backend = backend
         self._config.save()
 

--- a/src/interpreter/gui/workers.py
+++ b/src/interpreter/gui/workers.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import QObject, Signal
 
 from .. import log
 from ..config import Config, OverlayMode
+from ..languages import contains_japanese, contains_script  # noqa: F401  (contains_japanese kept for callers)
 from ..ocr import OCREngine, create_ocr
 from ..translate import TranslationEngine, create_translator
 
@@ -16,24 +17,6 @@ logger = log.get_logger()
 # (status "Error" + Fix Models) instead of retrying on every frame forever.
 MAX_CONSECUTIVE_TRANSLATION_FAILURES = 3
 MAX_CONSECUTIVE_OCR_FAILURES = 3
-
-
-def contains_japanese(text: str) -> bool:
-    """Check if text contains Japanese characters."""
-    for char in text:
-        code = ord(char)
-        # Hiragana: U+3040-U+309F
-        # Katakana: U+30A0-U+30FF
-        # CJK (Kanji): U+4E00-U+9FFF
-        # Half-width Katakana: U+FF65-U+FF9F
-        if (
-            0x3040 <= code <= 0x309F  # Hiragana
-            or 0x30A0 <= code <= 0x30FF  # Katakana
-            or 0x4E00 <= code <= 0x9FFF  # Kanji
-            or 0xFF65 <= code <= 0xFF9F  # Half-width Katakana
-        ):
-            return True
-    return False
 
 
 class FrameBuffer:
@@ -364,9 +347,10 @@ class ProcessWorker(QObject):
                 self._emit(self.text_ready, "")
             return
 
-        # Skip translation for non-Japanese text
-        if not contains_japanese(text):
-            logger.debug("skipping translation - no Japanese characters detected")
+        # Skip translation when nothing looks like the source language (OCR garbage)
+        language = self._config.source_language
+        if not contains_script(text, language):
+            logger.debug("skipping translation - no source-language text detected", language=language)
             if self._mode == OverlayMode.INPLACE:
                 self._emit(self.regions_ready, [])
             else:
@@ -380,12 +364,9 @@ class ProcessWorker(QObject):
             all_cached = True
             for region in regions:
                 if self._translator and region.text:
-                    # Skip non-Japanese regions
-                    if not contains_japanese(region.text):
-                        logger.debug(
-                            "skipping region - no Japanese characters",
-                            text=region.text[:30],
-                        )
+                    # Skip regions with nothing in the source language's script
+                    if not contains_script(region.text, language):
+                        logger.debug("skipping region - no source-language text", text=region.text[:30])
                         continue
                     try:
                         translated, cached = self._translator.translate(region.text)

--- a/src/interpreter/languages.py
+++ b/src/interpreter/languages.py
@@ -1,0 +1,84 @@
+"""Source languages the app can read, and cheap script checks for their text.
+
+The OCR output is gated on "does this look like text in the source language?"
+before translation, so that OCR garbage from decorations or UI chrome is not
+translated. The check is deliberately loose: it only asks whether at least one
+character belongs to the language's script.
+"""
+
+DEFAULT_SOURCE_LANGUAGE = "Japanese"
+
+# Display names double as config values and as the words used in the LLM prompt.
+SOURCE_LANGUAGES = (
+    "Japanese",
+    "Chinese",
+    "Korean",
+    "English",
+    "French",
+    "German",
+    "Spanish",
+    "Italian",
+    "Portuguese",
+    "Russian",
+)
+
+# Inclusive code point ranges per script
+_KANA = ((0x3040, 0x309F), (0x30A0, 0x30FF), (0xFF65, 0xFF9F))  # hiragana, katakana, half-width katakana
+_HAN = ((0x4E00, 0x9FFF), (0x3400, 0x4DBF), (0xF900, 0xFAFF))  # CJK unified, extension A, compatibility
+_HANGUL = ((0xAC00, 0xD7AF), (0x1100, 0x11FF), (0x3130, 0x318F))  # syllables, jamo, compatibility jamo
+_LATIN = ((0x41, 0x5A), (0x61, 0x7A), (0xC0, 0x24F), (0xFF21, 0xFF3A), (0xFF41, 0xFF5A))  # incl. accents, full-width
+_CYRILLIC = ((0x0400, 0x04FF),)
+
+_SCRIPTS = {
+    "Japanese": _KANA + _HAN,
+    "Chinese": _HAN,
+    "Korean": _HANGUL + _HAN,  # hanja still appear in some games
+    "English": _LATIN,
+    "French": _LATIN,
+    "German": _LATIN,
+    "Spanish": _LATIN,
+    "Italian": _LATIN,
+    "Portuguese": _LATIN,
+    "Russian": _CYRILLIC,
+}
+assert set(_SCRIPTS) == set(SOURCE_LANGUAGES)
+
+# Samples used to warm up and test a translation endpoint.
+SAMPLE_TEXT = {
+    "Japanese": "はじめまして。わたしはユウキです。",
+    "Chinese": "你好，勇者。欢迎来到我们的村庄。",
+    "Korean": "안녕하세요, 용사님. 우리 마을에 오신 것을 환영합니다.",
+    "English": "Welcome, brave hero. The village needs your help.",
+    "French": "Bienvenue, brave héros. Le village a besoin de ton aide.",
+    "German": "Willkommen, tapferer Held. Das Dorf braucht deine Hilfe.",
+    "Spanish": "Bienvenido, valiente héroe. El pueblo necesita tu ayuda.",
+    "Italian": "Benvenuto, coraggioso eroe. Il villaggio ha bisogno del tuo aiuto.",
+    "Portuguese": "Bem-vindo, bravo herói. A vila precisa da sua ajuda.",
+    "Russian": "Добро пожаловать, храбрый герой. Деревне нужна твоя помощь.",
+}
+assert set(SAMPLE_TEXT) == set(SOURCE_LANGUAGES)
+
+
+def normalize_source_language(value: object) -> str:
+    """Map a config value to a supported language name (case-insensitive), or the default."""
+    text = str(value or "").strip().lower()
+    for language in SOURCE_LANGUAGES:
+        if language.lower() == text:
+            return language
+    return DEFAULT_SOURCE_LANGUAGE
+
+
+def contains_script(text: str, language: str) -> bool:
+    """True if ``text`` has at least one character from ``language``'s script."""
+    ranges = _SCRIPTS.get(language, _SCRIPTS[DEFAULT_SOURCE_LANGUAGE])
+    for char in text:
+        code = ord(char)
+        for low, high in ranges:
+            if low <= code <= high:
+                return True
+    return False
+
+
+def contains_japanese(text: str) -> bool:
+    """Check if text contains Japanese characters (kana or kanji)."""
+    return contains_script(text, "Japanese")

--- a/src/interpreter/llm_translate.py
+++ b/src/interpreter/llm_translate.py
@@ -12,6 +12,7 @@ import requests
 
 from . import log
 from .config import LLM_PROVIDERS, LLMSettings
+from .languages import DEFAULT_SOURCE_LANGUAGE, SAMPLE_TEXT
 from .models import ModelLoadError
 from .translate import (
     DEFAULT_CACHE_SIZE,
@@ -39,10 +40,10 @@ DEFAULT_BASE_URLS = {
 }
 
 DEFAULT_SYSTEM_PROMPT = (
-    "You translate text captured by OCR from a Japanese retro video game. "
-    "Translate the user's message from Japanese into {target_language}. "
+    "You translate text captured by OCR from a {source_language} retro video game. "
+    "Translate the user's message from {source_language} into {target_language}. "
     "Keep character names as they appear, keep menu items in the same order, "
-    "and do not add explanations, notes, romaji or quotation marks. "
+    "and do not add explanations, notes, transliterations or quotation marks. "
     "Output only the translation."
 )
 
@@ -57,11 +58,11 @@ OLLAMA_KEEP_ALIVE = "30m"
 # Minimum timeout for the warm-up request, during which the server loads the model.
 LOAD_TIMEOUT = 120.0
 
-# Sent once at load time so the first real line does not pay the model load cost.
-WARMUP_TEXT = "こんにちは"
-
-# Sample used by the Settings "Test" button.
-TEST_TEXT = "はじめまして。わたしはユウキです。"
+# Sent once at load time so the first real line does not pay the model load cost,
+# and by the Settings "Test" button. One sample per source language (see languages.py).
+SAMPLE_TEXTS = SAMPLE_TEXT
+WARMUP_TEXT = SAMPLE_TEXT[DEFAULT_SOURCE_LANGUAGE]
+TEST_TEXT = SAMPLE_TEXT[DEFAULT_SOURCE_LANGUAGE]
 
 # Some OpenAI-compatible servers return the reasoning inline instead of in a separate field.
 THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
@@ -195,12 +196,14 @@ class LLMTranslator:
         settings: LLMSettings,
         cache_size: int = DEFAULT_CACHE_SIZE,
         similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+        source_language: str = DEFAULT_SOURCE_LANGUAGE,
     ):
         if settings.provider not in PROVIDERS:
             raise ModelLoadError(f"Unsupported LLM provider '{settings.provider}'. Use one of: {', '.join(PROVIDERS)}.")
         if not settings.timeout > 0:
             raise ModelLoadError(f"LLM timeout must be a positive number of seconds, got {settings.timeout!r}.")
         self._settings = settings
+        self._source_language = source_language or DEFAULT_SOURCE_LANGUAGE
         self._cache = TranslationCache(cache_size, similarity_threshold)
         self._history: deque[tuple[str, str]] = deque(maxlen=max(0, settings.context_lines))
         self._session = requests.Session()
@@ -212,9 +215,20 @@ class LLMTranslator:
         return f"{provider_label(self._settings.provider)} · {self._settings.model or 'no model'}"
 
     @property
+    def source_language(self) -> str:
+        return self._source_language
+
+    @property
+    def sample_text(self) -> str:
+        """A line in the source language, for warm-up and the Test button."""
+        return SAMPLE_TEXTS.get(self._source_language, WARMUP_TEXT)
+
+    @property
     def system_prompt(self) -> str:
         template = self._settings.system_prompt or DEFAULT_SYSTEM_PROMPT
-        return template.replace("{target_language}", self._settings.target_language or "English")
+        return template.replace("{target_language}", self._settings.target_language or "English").replace(
+            "{source_language}", self._source_language
+        )
 
     def load(self) -> None:
         """Validate the endpoint with a warm-up request.
@@ -240,7 +254,7 @@ class LLMTranslator:
         try:
             # The server loads the model on this first request, which can take far longer
             # than a normal translation (several GB read from disk), so allow extra time.
-            self._chat(self._build_messages(WARMUP_TEXT), timeout=max(self._settings.timeout, LOAD_TIMEOUT))
+            self._chat(self._build_messages(self.sample_text), timeout=max(self._settings.timeout, LOAD_TIMEOUT))
         except requests.RequestException as e:
             raise ModelLoadError(describe_request_error(e, self._settings)) from e
         self._loaded = True
@@ -346,7 +360,7 @@ class LLMTranslator:
         return choices[0].get("message", {}).get("content") or ""
 
 
-def check_endpoint(settings: LLMSettings) -> tuple[str, int]:
+def check_endpoint(settings: LLMSettings, source_language: str = DEFAULT_SOURCE_LANGUAGE) -> tuple[str, int]:
     """Load the endpoint and translate a sample line, for the Settings "Test" button.
 
     Returns:
@@ -356,8 +370,8 @@ def check_endpoint(settings: LLMSettings) -> tuple[str, int]:
         ModelLoadError: If the endpoint cannot be used.
         LLMTranslationError: If the sample translation fails.
     """
-    translator = LLMTranslator(settings, cache_size=1)
+    translator = LLMTranslator(settings, cache_size=1, source_language=source_language)
     translator.load()
     start = time.perf_counter()
-    translation, _ = translator.translate(TEST_TEXT)
+    translation, _ = translator.translate(translator.sample_text)
     return translation, int((time.perf_counter() - start) * 1000)

--- a/src/interpreter/translate.py
+++ b/src/interpreter/translate.py
@@ -367,12 +367,26 @@ class Translator:
         return self._translator is not None
 
 
+SUGOI_SOURCE_LANGUAGE = "Japanese"
+SUGOI_ONLY_JAPANESE = (
+    "Sugoi V4 only translates Japanese. Set the source language to Japanese or pick the LLM endpoint engine."
+)
+
+
 def create_translator(config: "Config") -> TranslationEngine:
-    """Build the translation engine selected in the configuration."""
+    """Build the translation engine selected in the configuration.
+
+    Raises:
+        ModelLoadError: If the built-in engine cannot handle the configured source language.
+    """
     from .config import TranslationBackend
 
     if config.translation_backend == TranslationBackend.LLM:
         from .llm_translate import LLMTranslator
 
-        return LLMTranslator(config.llm)
+        return LLMTranslator(config.llm, source_language=config.source_language)
+    if config.source_language != SUGOI_SOURCE_LANGUAGE:
+        from .models import ModelLoadError
+
+        raise ModelLoadError(SUGOI_ONLY_JAPANESE)
     return Translator()

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import QApplication, QComboBox, QLabel, QLineEdit, QPlain
 
 from interpreter.config import Config, LLMSettings, OCRBackend, OwocrSettings, TranslationBackend
 from interpreter.gui.main_window import MainWindow
+from interpreter.languages import SOURCE_LANGUAGES
 from interpreter.llm_translate import DEFAULT_SYSTEM_PROMPT, PROVIDER_LABELS, PROVIDERS
 
 
@@ -34,7 +35,55 @@ def _panel(config: Config) -> MainWindow:
     win._llm_result_label = QLabel()
     win._llm_refresh_request = None
     win._llm_test_request = None
+    win._llm_test_language = config.source_language
+    # The Test button reads the pending source language from the OCR group
+    win._ocr_engine_combo = QComboBox()
+    win._ocr_engine_combo.addItem("MeikiOCR", OCRBackend.MEIKI.value)
+    win._ocr_engine_combo.addItem("owocr", OCRBackend.OWOCR.value)
+    win._ocr_engine_combo.setCurrentIndex(win._ocr_engine_combo.findData(config.ocr_backend.value))
+    win._source_language_combo = QComboBox()
+    for language in SOURCE_LANGUAGES:
+        win._source_language_combo.addItem(language, language)
+    win._source_language_combo.setCurrentIndex(win._source_language_combo.findData(config.source_language))
     return win
+
+
+def test_llm_test_uses_the_pending_source_language(qapp, monkeypatch):
+    """Greptile: Test must validate the language the user selected, not the last applied one."""
+    import interpreter.gui.main_window as module
+
+    seen = {}
+
+    def fake_check(settings, source_language):
+        seen["language"] = source_language
+        return ("Bonjour", 3)
+
+    class _Inline:
+        def __init__(self, target, daemon):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(module, "check_endpoint", fake_check)
+    monkeypatch.setattr(module.threading, "Thread", _Inline)
+    win = _panel(Config(ocr_backend=OCRBackend.OWOCR, llm=LLMSettings(model="m"), source_language="Japanese"))
+    done = []
+    win._llm_test_result = type("S", (), {"emit": lambda self, payload: done.append(payload)})()
+    win._source_language_combo.setCurrentIndex(win._source_language_combo.findData("Korean"))  # not applied yet
+
+    win._test_llm_endpoint()
+
+    assert seen["language"] == "Korean"
+    assert "Korean sample" in win._llm_result_label.toolTip()
+    win._on_llm_test_done(done[0])
+    assert win._llm_result_label.toolTip() == "OK in 3 ms: Bonjour"
+
+    # Language changed while a test was in flight: the result is discarded
+    win._test_llm_endpoint()
+    win._source_language_combo.setCurrentIndex(win._source_language_combo.findData("Chinese"))
+    win._on_llm_test_done(done[1])
+    assert "click Test again" in win._llm_result_label.toolTip()
 
 
 def _ocr_panel(config: Config) -> MainWindow:

--- a/tests/test_source_language.py
+++ b/tests/test_source_language.py
@@ -307,6 +307,23 @@ class TestMainWindow:
         assert config.source_language == "Japanese"
         win._process_worker.reload_translation.assert_called_once()  # prompt no longer says Chinese
 
+    def test_fix_models_does_not_delete_sugoi_for_a_language_conflict(self, qapp, monkeypatch):
+        """A hand-edited config pairing Sugoi with a non-Japanese source must not wipe the model cache."""
+        config = Config(
+            ocr_backend=OCRBackend.OWOCR, translation_backend=TranslationBackend.SUGOI, source_language="Korean"
+        )
+        win = _panel(config)
+        win._fixing_ocr = win._fixing_translation = False
+        win._process_worker.get_failed_models.return_value = ["translation"]
+        deleted = []
+        monkeypatch.setattr("interpreter.models.delete_model_cache", deleted.append)
+
+        win._on_fix_models()
+
+        assert deleted == []
+        win._process_worker.reload_translation.assert_called_once()
+        win._process_worker.stop.assert_not_called()  # no worker restart, nothing to download
+
     def test_apply_translation_refuses_sugoi_with_non_japanese_source(self, qapp):
         config = Config(
             ocr_backend=OCRBackend.OWOCR, translation_backend=TranslationBackend.LLM, source_language="English"

--- a/tests/test_source_language.py
+++ b/tests/test_source_language.py
@@ -1,0 +1,322 @@
+"""Tests for source languages other than Japanese: script checks, config, engines, worker gate, GUI."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from PySide6.QtWidgets import QApplication, QComboBox, QLabel, QLineEdit, QPushButton
+
+from interpreter.config import Config, LLMSettings, OCRBackend, OverlayMode, OwocrSettings, TranslationBackend
+from interpreter.gui.main_window import MainWindow
+from interpreter.gui.workers import ProcessWorker
+from interpreter.languages import (
+    DEFAULT_SOURCE_LANGUAGE,
+    SAMPLE_TEXT,
+    SOURCE_LANGUAGES,
+    contains_japanese,
+    contains_script,
+    normalize_source_language,
+)
+from interpreter.llm_translate import DEFAULT_SYSTEM_PROMPT, LLMTranslator, check_endpoint
+from interpreter.models import ModelLoadError
+from interpreter.ocr import OCRResult
+from interpreter.translate import SUGOI_ONLY_JAPANESE, Translator, create_translator
+
+
+class TestScriptChecks:
+    @pytest.mark.parametrize("language", SOURCE_LANGUAGES)
+    def test_each_language_accepts_its_own_sample(self, language):
+        assert contains_script(SAMPLE_TEXT[language], language)
+
+    @pytest.mark.parametrize(
+        ("text", "language", "expected"),
+        [
+            ("こんにちは", "Japanese", True),
+            ("勇者", "Japanese", True),
+            ("ｶﾀｶﾅ", "Japanese", True),
+            ("Hello", "Japanese", False),
+            ("你好", "Chinese", True),
+            ("こんにちは", "Chinese", False),  # kana only, no Han
+            ("안녕", "Korean", True),
+            ("漢字", "Korean", True),  # hanja
+            ("Hello", "Korean", False),
+            ("Hello", "English", True),
+            ("héros", "French", True),
+            ("Ｈｅｌｌｏ", "English", True),  # full-width Latin from some OCR engines
+            ("こんにちは", "English", False),
+            ("12345 !?", "English", False),
+            ("Привет", "Russian", True),
+            ("Hello", "Russian", False),
+            ("", "Japanese", False),
+        ],
+    )
+    def test_script_membership(self, text, language, expected):
+        assert contains_script(text, language) is expected
+
+    def test_unknown_language_falls_back_to_japanese_rules(self):
+        assert contains_script("こんにちは", "Klingon")
+        assert not contains_script("Hello", "Klingon")
+
+    def test_contains_japanese_is_kept_for_callers(self):
+        assert contains_japanese("やあ")
+        assert not contains_japanese("hi")
+
+    def test_normalize_source_language(self):
+        assert normalize_source_language("french") == "French"
+        assert normalize_source_language(" KOREAN ") == "Korean"
+        assert normalize_source_language("Klingon") == DEFAULT_SOURCE_LANGUAGE
+        assert normalize_source_language(None) == DEFAULT_SOURCE_LANGUAGE
+
+
+class TestConfig:
+    def test_default_is_japanese_and_is_written(self, tmp_path):
+        path = tmp_path / "config.yml"
+        Config().save(str(path))
+        assert "source_language: Japanese" in path.read_text(encoding="utf-8")
+        assert Config.load(str(path)).source_language == "Japanese"
+
+    def test_round_trip(self, tmp_path):
+        path = tmp_path / "config.yml"
+        Config(source_language="Korean").save(str(path))
+        assert Config.load(str(path)).source_language == "Korean"
+
+    def test_case_insensitive_and_invalid_values(self, tmp_path):
+        path = tmp_path / "config.yml"
+        path.write_text("source_language: german\n", encoding="utf-8")
+        assert Config.load(str(path)).source_language == "German"
+        path.write_text("source_language: klingon\n", encoding="utf-8")
+        assert Config.load(str(path)).source_language == "Japanese"
+        path.write_text("window_title: x\n", encoding="utf-8")
+        assert Config.load(str(path)).source_language == "Japanese"
+
+
+class TestTranslationEngines:
+    def test_sugoi_refuses_non_japanese_sources(self):
+        with pytest.raises(ModelLoadError, match="only translates Japanese"):
+            create_translator(Config(source_language="Chinese"))
+        assert isinstance(create_translator(Config(source_language="Japanese")), Translator)
+
+    def test_llm_engine_receives_the_source_language(self):
+        config = Config(
+            translation_backend=TranslationBackend.LLM, llm=LLMSettings(model="m"), source_language="Korean"
+        )
+        translator = create_translator(config)
+        assert isinstance(translator, LLMTranslator)
+        assert translator.source_language == "Korean"
+        assert translator.sample_text == SAMPLE_TEXT["Korean"]
+
+    def test_default_prompt_names_both_languages(self):
+        translator = LLMTranslator(LLMSettings(model="m", target_language="English"), source_language="Chinese")
+        prompt = translator.system_prompt
+        assert "from Chinese into English" in prompt
+        assert "{source_language}" not in prompt and "{target_language}" not in prompt
+        assert "{source_language}" in DEFAULT_SYSTEM_PROMPT
+
+    def test_old_custom_prompts_without_the_placeholder_still_work(self):
+        settings = LLMSettings(model="m", target_language="French", system_prompt="Translate to {target_language}.")
+        translator = LLMTranslator(settings, source_language="English")
+        assert translator.system_prompt == "Translate to French."
+
+    def test_warmup_and_test_use_a_sample_in_the_source_language(self):
+        translator = LLMTranslator(LLMSettings(model="m"), source_language="Russian")
+        translator._session.post = MagicMock(
+            return_value=MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"message": {"content": "ok"}}),
+                raise_for_status=MagicMock(),
+            )
+        )
+        translator.load()
+        sent = translator._session.post.call_args.kwargs["json"]["messages"]
+        assert sent[-1]["content"] == SAMPLE_TEXT["Russian"]
+        assert "from Russian" in sent[0]["content"]
+
+    def test_check_endpoint_translates_the_source_sample(self, monkeypatch):
+        seen = {}
+
+        def fake_load(self):
+            self._loaded = True
+
+        def fake_translate(self, text):
+            seen["text"] = text
+            return "Bonjour", False
+
+        monkeypatch.setattr(LLMTranslator, "load", fake_load)
+        monkeypatch.setattr(LLMTranslator, "translate", fake_translate)
+        translation, ms = check_endpoint(LLMSettings(model="m"), "German")
+        assert translation == "Bonjour" and ms >= 0
+        assert seen["text"] == SAMPLE_TEXT["German"]
+
+
+class _EchoTranslator:
+    name = "echo"
+
+    def __init__(self):
+        self.calls = []
+
+    def load(self):
+        pass
+
+    def is_loaded(self):
+        return True
+
+    def translate(self, text):
+        self.calls.append(text)
+        return f"<{text}>", False
+
+
+def _worker(source_language: str, regions: list[OCRResult], mode=OverlayMode.INPLACE):
+    worker = ProcessWorker(Config(source_language=source_language))
+    worker.set_mode(mode)
+    worker._ocr = MagicMock()
+    worker._ocr.extract_text_regions.return_value = regions
+    worker._translator = _EchoTranslator()
+    outputs = []
+    worker.regions_ready.connect(outputs.append)
+    worker.text_ready.connect(outputs.append)
+    return worker, outputs
+
+
+class TestWorkerGate:
+    REGIONS = [
+        OCRResult("Hello", {"x": 0, "y": 0, "width": 1, "height": 1}),
+        OCRResult("こんにちは", {"x": 0, "y": 10, "width": 1, "height": 1}),
+        OCRResult("###", {"x": 0, "y": 20, "width": 1, "height": 1}),
+    ]
+
+    def test_japanese_source_keeps_only_japanese_regions(self):
+        worker, outputs = _worker("Japanese", self.REGIONS)
+        worker._process_frame("frame")
+        assert worker._translator.calls == ["こんにちは"]
+        assert outputs == [[["<こんにちは>", {"x": 0, "y": 10, "width": 1, "height": 1}]]]  # Qt turns tuples into lists
+
+    def test_english_source_keeps_only_latin_regions(self):
+        worker, outputs = _worker("English", self.REGIONS)
+        worker._process_frame("frame")
+        assert worker._translator.calls == ["Hello"]
+        assert outputs == [[["<Hello>", {"x": 0, "y": 0, "width": 1, "height": 1}]]]
+
+    def test_frame_without_source_text_is_not_translated(self):
+        worker, outputs = _worker("Russian", self.REGIONS)
+        worker._process_frame("frame")
+        assert worker._translator.calls == []
+        assert outputs == [[]]
+
+    def test_banner_mode_uses_the_same_gate(self):
+        worker, outputs = _worker("English", self.REGIONS[:1], mode=OverlayMode.BANNER)
+        worker._process_frame("frame")
+        assert outputs == ["<Hello>"]
+
+    def test_language_change_in_config_applies_on_the_next_frame(self):
+        worker, _ = _worker("Japanese", self.REGIONS)
+        worker._process_frame("frame")
+        worker._config.source_language = "English"
+        worker._process_frame("frame")
+        assert worker._translator.calls == ["こんにちは", "Hello"]
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _panel(config: Config) -> MainWindow:
+    """A MainWindow with the OCR group's widgets plus what the Apply guards touch, skipping __init__."""
+    win = MainWindow.__new__(MainWindow)
+    win._config = config
+    win._ocr_engine_combo = QComboBox()
+    win._ocr_engine_combo.addItem("MeikiOCR", OCRBackend.MEIKI.value)
+    win._ocr_engine_combo.addItem("owocr", OCRBackend.OWOCR.value)
+    win._ocr_engine_combo.setCurrentIndex(win._ocr_engine_combo.findData(config.ocr_backend.value))
+    win._source_language_combo = QComboBox()
+    for language in SOURCE_LANGUAGES:
+        win._source_language_combo.addItem(language, language)
+    win._source_language_combo.setCurrentIndex(win._source_language_combo.findData(config.source_language))
+    win._owocr_panel = MagicMock()
+    win._owocr_url_edit = QLineEdit(config.owocr.url)
+    win._owocr_result_label = QLabel()
+    win._ocr_engine_label = QLabel()
+    win._ocr_status_label = QLabel()
+    win._translation_status_label = QLabel()
+    win._fix_models_btn = QPushButton()
+    win._engine_combo = QComboBox()
+    win._engine_combo.addItem("Sugoi", TranslationBackend.SUGOI.value)
+    win._engine_combo.addItem("LLM", TranslationBackend.LLM.value)
+    win._engine_combo.setCurrentIndex(win._engine_combo.findData(config.translation_backend.value))
+    win._process_worker = MagicMock()
+    win._grow_to_fit = MagicMock()
+    win.statusBar = MagicMock()
+    config.save = MagicMock()
+    return win
+
+
+class TestMainWindow:
+    def test_meiki_pins_the_language_to_japanese(self, qapp):
+        win = _panel(Config(source_language="Korean"))  # e.g. hand-edited config with MeikiOCR
+        win._sync_source_language_combo()
+        assert not win._source_language_combo.isEnabled()
+        assert win._source_language_combo.currentData() == "Japanese"
+        assert win._selected_source_language() == "Japanese"
+
+    def test_owocr_unlocks_the_language(self, qapp):
+        win = _panel(Config(ocr_backend=OCRBackend.OWOCR, source_language="Korean"))
+        win._sync_source_language_combo()
+        assert win._source_language_combo.isEnabled()
+        assert win._selected_source_language() == "Korean"
+
+    def test_switching_engine_back_to_meiki_resets_the_language(self, qapp):
+        win = _panel(Config(ocr_backend=OCRBackend.OWOCR, source_language="Korean"))
+        win._ocr_engine_combo.setCurrentIndex(win._ocr_engine_combo.findData(OCRBackend.MEIKI.value))
+        win._on_ocr_engine_changed(0)
+        assert win._selected_source_language() == "Japanese"
+        assert not win._source_language_combo.isEnabled()
+
+    def test_apply_ocr_refuses_non_japanese_with_sugoi(self, qapp):
+        config = Config(ocr_backend=OCRBackend.OWOCR, owocr=OwocrSettings())
+        win = _panel(config)
+        win._source_language_combo.setCurrentIndex(win._source_language_combo.findData("English"))
+
+        win._apply_ocr_settings()
+
+        assert win._owocr_result_label.toolTip() == SUGOI_ONLY_JAPANESE
+        assert config.source_language == "Japanese"
+        config.save.assert_not_called()
+        win._process_worker.reload_ocr.assert_not_called()
+
+    def test_apply_ocr_saves_the_language_and_reloads_both_engines(self, qapp):
+        config = Config(ocr_backend=OCRBackend.OWOCR, translation_backend=TranslationBackend.LLM)
+        win = _panel(config)
+        win._source_language_combo.setCurrentIndex(win._source_language_combo.findData("Chinese"))
+
+        win._apply_ocr_settings()
+
+        assert config.source_language == "Chinese"
+        config.save.assert_called_once()
+        win._process_worker.reload_ocr.assert_called_once()
+        win._process_worker.reload_translation.assert_called_once()
+
+    def test_apply_ocr_with_meiki_forces_japanese(self, qapp):
+        config = Config(
+            ocr_backend=OCRBackend.OWOCR, translation_backend=TranslationBackend.LLM, source_language="Chinese"
+        )
+        win = _panel(config)
+        win._ocr_engine_combo.setCurrentIndex(win._ocr_engine_combo.findData(OCRBackend.MEIKI.value))
+
+        win._apply_ocr_settings()
+
+        assert config.ocr_backend == OCRBackend.MEIKI
+        assert config.source_language == "Japanese"
+        win._process_worker.reload_translation.assert_called_once()  # prompt no longer says Chinese
+
+    def test_apply_translation_refuses_sugoi_with_non_japanese_source(self, qapp):
+        config = Config(
+            ocr_backend=OCRBackend.OWOCR, translation_backend=TranslationBackend.LLM, source_language="English"
+        )
+        win = _panel(config)
+        win._engine_combo.setCurrentIndex(win._engine_combo.findData(TranslationBackend.SUGOI.value))
+
+        win._apply_translation_settings()
+
+        assert config.translation_backend == TranslationBackend.LLM
+        assert win._translation_status_label.toolTip() == SUGOI_ONLY_JAPANESE
+        win.statusBar().showMessage.assert_called_with(SUGOI_ONLY_JAPANESE)
+        config.save.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #265 (asked for in #190 and #141).

Both engines are pluggable now (translation in v2.19.0, OCR in v2.20.0), but the pipeline still assumed Japanese: the worker dropped any OCR text without kana or kanji, the LLM prompt hardcoded "from Japanese", and the built-in engines only handle Japanese anyway. This adds a **Source language** setting and removes those assumptions.

Design decisions (agreed before starting):
- The dropdown lives in the **OCR** group. It is **pinned to Japanese and greyed out while MeikiOCR is selected**, since MeikiOCR reads Japanese only, and unlocks with owocr.
- A non-Japanese source with **Sugoi V4 is refused on Apply** from either panel with a clear message, and `create_translator` raises the same message at load time if the config was hand-edited into that state. Nothing switches silently.
- Ten languages: Japanese, Chinese, Korean, English, French, German, Spanish, Italian, Portuguese, Russian.

## What changed

- **`languages.py`** (new): `SOURCE_LANGUAGES`, a per-script `contains_script()` check (kana/kanji, Han, Hangul, Latin incl. accents and full-width, Cyrillic) that replaces the Japanese-only gate, `normalize_source_language()`, and a sample line per language for endpoint warm-up and the Test button.
- **Config**: `source_language` (validated, case-insensitive, default `Japanese`, always written).
- **Worker**: the translation gate uses the configured language's script, in banner and inplace mode.
- **LLM engine**: `{source_language}` in the default prompt (old custom prompts without it still work); warm-up and Test use the source-language sample; the factory passes the language through.
- **Sugoi**: `create_translator` raises `ModelLoadError` for a non-Japanese source.
- **GUI**: Source language row in the OCR group with the pinning logic; both Apply guards; changing the language reloads the translation engine as well since the prompt names it; the prompt tooltip mentions both placeholders.
- **README**: new *Games in Other Languages* section, and the two "Japanese only" notes updated.
- **Tests**: `tests/test_source_language.py` (51 tests): script checks per language, config round trip and validation, engine factory and prompt behaviour, worker gate per language in both modes, and the GUI pinning and refusal logic.

## Verification

- `uv run pytest`: 275 passed (52 new). `ruff check` clean.
- Live, in the real app, five significant combinations:
  - **Japanese default path** (MeikiOCR + Sugoi V4): unchanged, all three lines read and translated. This is the regression check for the replaced gate.
  - **English source** via owocr with OneOCR, `gemma3:12b` through Ollama into French: all lines read, translated and placed by the inplace overlay. Applying Sugoi with this source was refused with the message; switching the OCR engine to MeikiOCR pinned the dropdown back to Japanese.
  - **Chinese source** via owocr with OneOCR (no language hint needed), `gemma3:12b` into English: read and translated correctly.
  - **Korean source** via owocr with OneOCR (no language hint needed), `gemma3:12b` into English: all three Hangul lines read and translated correctly.
  - **Hand-edited conflict** (owocr + Korean + Sugoi): the translation status turns to Error at startup with the "only translates Japanese" message, capture stays disabled, and Fix Models reloads without deleting the Sugoi cache (second commit).

Not run live: Russian and the European languages (unit-tested script checks only), banner mode (unit-tested), Google Lens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

