### PR TITLE
Capture from video devices (capture cards, webcams) through Qt Multimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ interpreter-v2
 
 This opens the GUI where you can select a window to capture and configure all settings.
 
+### Capturing a console through a capture card
+
+The source list also shows video devices (capture cards, webcams). Pick your card there to translate a console game without going through OBS: the console plays on the TV through the card's passthrough, and the banner with the translation floats on the PC screen. Video sources are banner mode only, since there is no window on screen to draw over. Exclusion zones and the OCR confidence are remembered per device, like they are per window.
+
+On macOS the first capture triggers the camera permission prompt for the terminal that launched Interpreter.
+
 ## Overlay Modes
 
 ### Banner Mode (default)

--- a/src/interpreter/capture/video_device.py
+++ b/src/interpreter/capture/video_device.py
@@ -45,9 +45,25 @@ def list_video_devices() -> list[QCameraDevice]:
     return list(QMediaDevices.videoInputs())
 
 
-def find_video_device(name: str) -> QCameraDevice | None:
-    """Find an attached device by its description (the name shown in the source list)."""
-    for device in list_video_devices():
+def device_id(device: QCameraDevice) -> str:
+    """The device's unique id as text (a Media Foundation symbolic link, an AVFoundation unique
+    id, or a /dev/video path). Tells two devices of the same model apart."""
+    return bytes(device.id()).decode("utf-8", "replace")
+
+
+def find_video_device(name: str, id_text: str = "") -> QCameraDevice | None:
+    """Find an attached device, by unique id when one is given, else by description.
+
+    The id wins when it is present: two cards of the same model share a description.
+    The name is the fallback because ids can change on Linux (/dev/video numbering
+    follows plug order) while the description stays put.
+    """
+    devices = list_video_devices()
+    if id_text:
+        for device in devices:
+            if device_id(device) == id_text:
+                return device
+    for device in devices:
         if device.description() == name:
             return device
     return None

--- a/src/interpreter/capture/video_device.py
+++ b/src/interpreter/capture/video_device.py
@@ -1,0 +1,195 @@
+"""Video device capture (capture cards, webcams) through Qt Multimedia.
+
+Capture cards show up as standard UVC video devices, so this source reads from them the same
+way it would read from a webcam. Qt's FFmpeg multimedia backend handles the platform camera
+API (Media Foundation on Windows, AVFoundation on macOS, V4L2 on Linux) and ships inside the
+PySide6 wheels, so no extra dependency is needed.
+
+Unlike a window there is nothing on the desktop to anchor an overlay to: the game plays on a TV
+through the card's passthrough. The source therefore reports no bounds and the GUI keeps the
+translation in banner mode.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+from PySide6.QtCore import QObject, Slot
+from PySide6.QtGui import QImage
+from PySide6.QtMultimedia import (
+    QCamera,
+    QCameraDevice,
+    QCameraFormat,
+    QMediaCaptureSession,
+    QMediaDevices,
+    QVideoFrame,
+    QVideoFrameFormat,
+    QVideoSink,
+)
+
+from .. import log
+
+logger = log.get_logger()
+
+# Frames larger than this are not worth decoding at the device's frame rate just to OCR a few
+# frames a second; 1080p is plenty for text detection.
+MAX_FRAME_AREA = 1920 * 1080
+
+# Uncompressed modes below this frame rate (USB 2 cards often expose 1080p YUY2 at 5 fps)
+# rank below an MJPEG mode at a usable rate.
+MIN_UNCOMPRESSED_FPS = 10.0
+
+
+def list_video_devices() -> list[QCameraDevice]:
+    """Video input devices currently attached, in Qt's order (default device first)."""
+    return list(QMediaDevices.videoInputs())
+
+
+def find_video_device(name: str) -> QCameraDevice | None:
+    """Find an attached device by its description (the name shown in the source list)."""
+    for device in list_video_devices():
+        if device.description() == name:
+            return device
+    return None
+
+
+def _is_compressed(pixel_format: QVideoFrameFormat.PixelFormat) -> bool:
+    return pixel_format == QVideoFrameFormat.PixelFormat.Format_Jpeg
+
+
+def choose_format(formats: list[QCameraFormat]) -> QCameraFormat | None:
+    """Pick the mode to open a device in.
+
+    Largest resolution up to 1080p wins. Within a resolution, an uncompressed mode at a usable
+    frame rate is preferred over MJPEG (no decoding), then the higher frame rate wins.
+    Devices that only offer modes above 1080p fall back to the smallest of those.
+    """
+    if not formats:
+        return None
+
+    def key(fmt: QCameraFormat):
+        size = fmt.resolution()
+        area = size.width() * size.height()
+        within_cap = area <= MAX_FRAME_AREA
+        fps = fmt.maxFrameRate()
+        cheap = not _is_compressed(fmt.pixelFormat()) and fps >= MIN_UNCOMPRESSED_FPS
+        return (
+            0 if within_cap else 1,
+            -area if within_cap else area,
+            0 if cheap else 1,
+            -min(fps, 60.0),
+        )
+
+    return min(formats, key=key)
+
+
+def qimage_to_bgra(image: QImage) -> NDArray[np.uint8]:
+    """Copy a QImage into a (H, W, 4) BGRA numpy array, the format every capture source returns."""
+    if image.format() != QImage.Format.Format_ARGB32:
+        image = image.convertToFormat(QImage.Format.Format_ARGB32)
+    height, width, stride = image.height(), image.width(), image.bytesPerLine()
+    # ARGB32 is one 0xAARRGGBB uint32 per pixel, stored little-endian: B, G, R, A in memory
+    rows = np.frombuffer(image.constBits(), dtype=np.uint8).reshape(height, stride)
+    return rows[:, : width * 4].reshape(height, width, 4).copy()
+
+
+class VideoDeviceCapture(QObject):
+    """Capture source reading from a video device, conforming to the Capture protocol.
+
+    Qt keeps the device streaming at its own frame rate; get_frame() converts whichever frame
+    is current when the GUI's processing timer fires.
+    """
+
+    def __init__(self, device: QCameraDevice, parent: QObject | None = None):
+        super().__init__(parent)
+        self._device = device
+        self._invalid = False
+        self._error: str | None = None
+        self._frames = 0
+
+        self._camera = QCamera(device, self)
+        self._sink = QVideoSink(self)
+        self._session = QMediaCaptureSession(self)
+        self._session.setCamera(self._camera)
+        self._session.setVideoSink(self._sink)
+        self._camera.errorOccurred.connect(self._on_camera_error)
+        self._sink.videoFrameChanged.connect(self._on_frame)
+
+        # Unplugging the card doesn't always surface as a camera error
+        self._devices = QMediaDevices(self)
+        self._devices.videoInputsChanged.connect(self._on_devices_changed)
+
+    @property
+    def name(self) -> str:
+        return self._device.description()
+
+    @property
+    def error(self) -> str | None:
+        """Last camera error message, if any."""
+        return self._error
+
+    def start(self) -> None:
+        """Open the device in the chosen mode and start streaming."""
+        fmt = choose_format(list(self._device.videoFormats()))
+        if fmt is not None:
+            self._camera.setCameraFormat(fmt)
+            size = fmt.resolution()
+            logger.info(
+                "starting video device capture",
+                device=self.name,
+                width=size.width(),
+                height=size.height(),
+                fps=round(fmt.maxFrameRate(), 1),
+                pixel_format=fmt.pixelFormat().name,
+            )
+        else:
+            logger.info("starting video device capture with default format", device=self.name)
+        self._camera.start()
+
+    def get_frame(self) -> NDArray[np.uint8] | None:
+        frame = self._sink.videoFrame()
+        if not frame.isValid():
+            return None
+        image = frame.toImage()
+        if image.isNull():
+            return None
+        return qimage_to_bgra(image)
+
+    @property
+    def bounds(self) -> dict | None:
+        """No window on screen, so no bounds (banner mode only, like Wayland)."""
+        return None
+
+    @property
+    def window_invalid(self) -> bool:
+        return self._invalid
+
+    def get_content_offset(self) -> tuple[int, int]:
+        return (0, 0)
+
+    def stop(self) -> None:
+        logger.info("stopping video device capture", device=self.name, frames=self._frames)
+        self._camera.stop()
+        self._session.setCamera(None)
+        self._session.setVideoSink(None)
+        # The GUI drops its reference; free the Qt objects once the event loop is idle
+        self.deleteLater()
+
+    @Slot(QVideoFrame)
+    def _on_frame(self, frame: QVideoFrame) -> None:
+        self._frames += 1
+
+    @Slot(QCamera.Error, str)
+    def _on_camera_error(self, error: QCamera.Error, message: str) -> None:
+        if error == QCamera.Error.NoError:
+            return
+        logger.error("video device error", device=self.name, error=message)
+        self._error = message or "camera error"
+        self._invalid = True
+
+    @Slot()
+    def _on_devices_changed(self) -> None:
+        if not any(device.id() == self._device.id() for device in list_video_devices()):
+            logger.info("video device disconnected", device=self.name)
+            self._error = "device disconnected"
+            self._invalid = True

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -186,10 +186,14 @@ class Config:
         owocr: OwocrSettings | None = None,
         source_language: str = DEFAULT_SOURCE_LANGUAGE,
         video_device: str = "",
+        video_device_id: str = "",
     ):
         self.window_title = window_title
-        # Video device (capture card, webcam) captured last; empty means a window was captured last
+        # Video device (capture card, webcam) captured last; empty means a window was captured last.
+        # The name is what the user sees and what keys exclusion zones; the id tells two devices
+        # of the same model apart (it is matched first, the name is the fallback).
         self.video_device = video_device
+        self.video_device_id = video_device_id
         self.translation_backend = translation_backend
         self.llm = llm if llm is not None else LLMSettings()
         self.ocr_backend = ocr_backend
@@ -297,6 +301,7 @@ class Config:
                 owocr=OwocrSettings.from_dict(data.get("owocr")),
                 source_language=source_language,
                 video_device=str(data.get("video_device") or ""),
+                video_device_id=str(data.get("video_device_id") or ""),
             )
 
         # No config file found - create default in home directory
@@ -476,6 +481,8 @@ hotkeys:
         # Only written while a video device is the selected source
         if self.video_device:
             data["video_device"] = str(self.video_device)
+            if self.video_device_id:
+                data["video_device_id"] = str(self.video_device_id)
         # Only save font_family if user has chosen one (None = system default)
         if self.font_family is not None:
             data["font_family"] = str(self.font_family)

--- a/src/interpreter/config.py
+++ b/src/interpreter/config.py
@@ -185,8 +185,11 @@ class Config:
         ocr_backend: OCRBackend = OCRBackend.MEIKI,
         owocr: OwocrSettings | None = None,
         source_language: str = DEFAULT_SOURCE_LANGUAGE,
+        video_device: str = "",
     ):
         self.window_title = window_title
+        # Video device (capture card, webcam) captured last; empty means a window was captured last
+        self.video_device = video_device
         self.translation_backend = translation_backend
         self.llm = llm if llm is not None else LLMSettings()
         self.ocr_backend = ocr_backend
@@ -293,6 +296,7 @@ class Config:
                 ocr_backend=ocr_backend,
                 owocr=OwocrSettings.from_dict(data.get("owocr")),
                 source_language=source_language,
+                video_device=str(data.get("video_device") or ""),
             )
 
         # No config file found - create default in home directory
@@ -315,6 +319,10 @@ class Config:
         # Write default config with comments
         default_config = """# Window to capture (partial title match)
 window_title: "Snes9x"
+
+# Video device to capture instead of a window (capture card or webcam, by the name shown in
+# the source list). Banner mode only. Leave empty to capture a window.
+# video_device: ""
 
 # OCR confidence threshold (0.0-1.0)
 # Filters out low-confidence text detection
@@ -465,6 +473,9 @@ hotkeys:
         if self.ocr_backend == OCRBackend.OWOCR or self.owocr != OwocrSettings():
             data["owocr"] = self.owocr.to_dict()
         data["source_language"] = str(self.source_language)
+        # Only written while a video device is the selected source
+        if self.video_device:
+            data["video_device"] = str(self.video_device)
         # Only save font_family if user has chosen one (None = system default)
         if self.font_family is not None:
             data["font_family"] = str(self.font_family)

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -33,7 +33,7 @@ from PySide6.QtWidgets import (
 from .. import __version__, log
 from ..capture import Capture, WindowCapture, _is_wayland_session
 from ..capture.convert import bgra_to_rgb_pil
-from ..capture.video_device import VideoDeviceCapture, find_video_device, list_video_devices
+from ..capture.video_device import VideoDeviceCapture, device_id, find_video_device, list_video_devices
 from ..config import Config, LLMSettings, OCRBackend, OverlayMode, OwocrSettings, TranslationBackend
 from ..languages import DEFAULT_SOURCE_LANGUAGE, SOURCE_LANGUAGES
 from ..llm_translate import (
@@ -76,6 +76,7 @@ MAX_FONT_SIZE = 72
 
 # Fixed processing interval (2 FPS)
 PROCESS_INTERVAL_MS = 500
+NO_SIGNAL_NOTICE_MS = 3000  # video device session without frames before the status bar says so
 
 
 class MainWindow(QMainWindow):
@@ -113,8 +114,12 @@ class MainWindow(QMainWindow):
         self._is_wayland_session = _is_wayland_session
         self._wayland_portal = None  # WaylandPortalCapture instance (for managing portal session lifecycle)
         self._wayland_selecting = False  # Guard against re-entry during portal flow
-        # Overlay mode to restore after a video device session (video sources are banner only)
+        # Video device sessions are banner only; the user's mode is restored afterwards
+        self._banner_only = False
         self._mode_before_video: OverlayMode | None = None
+        # Consecutive processing ticks without a frame (a capture card with the console off)
+        self._frames_missing = 0
+        self._waiting_for_signal = False
         self._fixing_ocr = False  # Track if we're re-downloading OCR model
         self._fixing_translation = False  # Track if we're re-downloading translation model
 
@@ -1254,8 +1259,12 @@ class MainWindow(QMainWindow):
         """Refresh the source list: windows (or the Wayland picker) followed by video devices.
 
         Each item carries a (kind, value) tuple: ("portal", None), ("window", index into
-        self._windows_list) or ("device", device name).
+        self._windows_list) or ("device", (device id, device name)).
+
+        A source the user already picked stays selected when it is still there; otherwise
+        the source captured last (from the config) is selected.
         """
+        previous = self._source_key(self._window_combo.currentData())
         self._window_combo.clear()
         selected_idx = -1
 
@@ -1283,15 +1292,46 @@ class MainWindow(QMainWindow):
         if devices:
             if self._window_combo.count():
                 self._window_combo.insertSeparator(self._window_combo.count())
+            names_seen: dict[str, int] = {}
+            id_match = name_match = -1
             for device in devices:
                 name = device.description()
-                self._window_combo.addItem(f"Video device: {name}", ("device", name))
-                # A video device captured last wins over the window title match
-                if self._config.video_device and self._config.video_device == name:
-                    selected_idx = self._window_combo.count() - 1
+                id_text = device_id(device)
+                # Two cards of the same model: number the display text, the id tells them apart
+                names_seen[name] = names_seen.get(name, 0) + 1
+                label = f"Video device: {name}" + (f" ({names_seen[name]})" if names_seen[name] > 1 else "")
+                self._window_combo.addItem(label, ("device", (id_text, name)))
+                if self._config.video_device_id and self._config.video_device_id == id_text:
+                    id_match = self._window_combo.count() - 1
+                elif name_match < 0 and self._config.video_device and self._config.video_device == name:
+                    name_match = self._window_combo.count() - 1
+            # A video device captured last wins over the window title match: by id, else by name
+            device_match = id_match if id_match >= 0 else name_match
+            if device_match >= 0:
+                selected_idx = device_match
+
+        # Keep what the user had picked, if it is still there
+        if previous is not None:
+            for i in range(self._window_combo.count()):
+                if self._source_key(self._window_combo.itemData(i)) == previous:
+                    selected_idx = i
+                    break
 
         if selected_idx >= 0:
             self._window_combo.setCurrentIndex(selected_idx)
+
+    def _source_key(self, data) -> tuple | None:
+        """Stable identity of a source item, independent of its position in the list."""
+        if not data:
+            return None
+        kind, value = data
+        if kind == "window":
+            if value >= len(self._windows_list):
+                return None
+            return ("window", self._windows_list[value].get("id"))
+        if kind == "device":
+            return ("device", value[0])
+        return (kind,)
 
     def _on_video_devices_changed(self):
         """A video device was plugged in or removed; re-list unless a capture is running."""
@@ -1312,7 +1352,8 @@ class MainWindow(QMainWindow):
             self._start_wayland_capture()
             return
         if kind == "device":
-            self._start_video_capture(value)
+            id_text, name = value
+            self._start_video_capture(name, id_text)
             return
         if kind != "window" or value >= len(self._windows_list):
             self.statusBar().showMessage("No source selected")
@@ -1358,6 +1399,7 @@ class MainWindow(QMainWindow):
         # Update config with selected window
         self._config.window_title = title
         self._config.video_device = ""
+        self._config.video_device_id = ""
         self._current_window_title = title  # Store for exclusion zone lookup
 
         # Set per-window OCR confidence
@@ -1367,9 +1409,9 @@ class MainWindow(QMainWindow):
         # Show overlay
         self._show_overlay()
 
-    def _start_video_capture(self, name: str):
-        """Start capturing a video device (capture card, webcam) by name."""
-        device = find_video_device(name)
+    def _start_video_capture(self, name: str, id_text: str = ""):
+        """Start capturing a video device (capture card, webcam), by id when known, else by name."""
+        device = find_video_device(name, id_text)
         if device is None:
             self.statusBar().showMessage(f"Video device not found: {name[:40]}")
             self._refresh_sources()
@@ -1389,6 +1431,8 @@ class MainWindow(QMainWindow):
         self._process_timer.start()
 
         self._capturing = True
+        self._frames_missing = 0
+        self._waiting_for_signal = False
 
         self._last_ocr_results = []  # boxes from a previous session must not outlive it
         self._paused = False
@@ -1400,6 +1444,7 @@ class MainWindow(QMainWindow):
 
         # Remember the device; exclusion zones and OCR confidence are keyed by its name
         self._config.video_device = name
+        self._config.video_device_id = device_id(device)
         self._current_window_title = name
         self._process_worker.set_confidence_threshold(self._config.get_ocr_confidence(name))
 
@@ -1413,6 +1458,7 @@ class MainWindow(QMainWindow):
         The user's chosen mode is restored when the lock is lifted and is never written to
         the config by the forced switch.
         """
+        self._banner_only = banner_only
         if banner_only:
             self._inplace_btn.setEnabled(False)
             self._inplace_btn.setToolTip("Video devices have no window on screen to draw over: banner mode only")
@@ -1481,6 +1527,7 @@ class MainWindow(QMainWindow):
             # Store window title for exclusion zone lookup (Wayland doesn't have window titles)
             self._current_window_title = "Wayland Capture"
             self._config.video_device = ""
+            self._config.video_device_id = ""
 
             # Set per-window OCR confidence
             confidence = self._config.get_ocr_confidence(self._current_window_title)
@@ -1662,7 +1709,9 @@ class MainWindow(QMainWindow):
 
     def _on_mode_changed(self, button_id: int):
         """Handle mode selection change."""
-        self._apply_mode(OverlayMode.BANNER if button_id == 0 else OverlayMode.INPLACE, persist=True)
+        # A click on Banner during a video device session must not overwrite the saved choice
+        mode = OverlayMode.BANNER if button_id == 0 else OverlayMode.INPLACE
+        self._apply_mode(mode, persist=not self._banner_only)
 
     def _apply_mode(self, mode: OverlayMode, persist: bool):
         """Switch the overlay mode; persist=False for the temporary switch of a video device session."""
@@ -1724,7 +1773,19 @@ class MainWindow(QMainWindow):
             overlay.ensure_above(getattr(self._capture, "window_id", None))
 
         if frame is None:
+            # A capture card keeps the session open with no frames while the console is off;
+            # say so after a few seconds instead of leaving a silent blank preview
+            if isinstance(self._capture, VideoDeviceCapture):
+                self._frames_missing += 1
+                if self._frames_missing * PROCESS_INTERVAL_MS >= NO_SIGNAL_NOTICE_MS and not self._waiting_for_signal:
+                    self._waiting_for_signal = True
+                    self.statusBar().showMessage(f"Waiting for a video signal from '{self._capture.name[:40]}'...")
             return
+
+        if self._waiting_for_signal:
+            self._waiting_for_signal = False
+            self.statusBar().showMessage(f"Capturing video device '{self._capture.name[:40]}'")
+        self._frames_missing = 0
 
         self._last_frame = frame
         self._last_bounds = bounds

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -1554,6 +1554,10 @@ class MainWindow(QMainWindow):
             self._capture.stop()
             self._capture = None
 
+        # No-signal notice belongs to the video device session that just ended
+        self._frames_missing = 0
+        self._waiting_for_signal = False
+
         # Close Wayland portal session if active
         if self._wayland_portal:
             self._wayland_portal.close()
@@ -1782,9 +1786,9 @@ class MainWindow(QMainWindow):
                     self.statusBar().showMessage(f"Waiting for a video signal from '{self._capture.name[:40]}'...")
             return
 
-        if self._waiting_for_signal:
-            self._waiting_for_signal = False
+        if self._waiting_for_signal and isinstance(self._capture, VideoDeviceCapture):
             self.statusBar().showMessage(f"Capturing video device '{self._capture.name[:40]}'")
+        self._waiting_for_signal = False
         self._frames_missing = 0
 
         self._last_frame = frame

--- a/src/interpreter/gui/main_window.py
+++ b/src/interpreter/gui/main_window.py
@@ -5,6 +5,7 @@ import threading
 from PIL import ImageDraw
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtGui import QFont, QImage, QKeySequence, QPixmap
+from PySide6.QtMultimedia import QMediaDevices
 from PySide6.QtWidgets import (
     QButtonGroup,
     QColorDialog,
@@ -32,6 +33,7 @@ from PySide6.QtWidgets import (
 from .. import __version__, log
 from ..capture import Capture, WindowCapture, _is_wayland_session
 from ..capture.convert import bgra_to_rgb_pil
+from ..capture.video_device import VideoDeviceCapture, find_video_device, list_video_devices
 from ..config import Config, LLMSettings, OCRBackend, OverlayMode, OwocrSettings, TranslationBackend
 from ..languages import DEFAULT_SOURCE_LANGUAGE, SOURCE_LANGUAGES
 from ..llm_translate import (
@@ -111,6 +113,8 @@ class MainWindow(QMainWindow):
         self._is_wayland_session = _is_wayland_session
         self._wayland_portal = None  # WaylandPortalCapture instance (for managing portal session lifecycle)
         self._wayland_selecting = False  # Guard against re-entry during portal flow
+        # Overlay mode to restore after a video device session (video sources are banner only)
+        self._mode_before_video: OverlayMode | None = None
         self._fixing_ocr = False  # Track if we're re-downloading OCR model
         self._fixing_translation = False  # Track if we're re-downloading translation model
 
@@ -157,13 +161,17 @@ class MainWindow(QMainWindow):
         self._last_frame = None
         self._last_bounds = {}
 
+        # Re-list the sources when a capture card or webcam is plugged in or removed
+        self._media_devices = QMediaDevices(self)
+        self._media_devices.videoInputsChanged.connect(self._on_video_devices_changed)
+
         self._setup_ui()
         # Auto-size window to fit all widgets, then lock minimum size
         self.adjustSize()
         self.setMinimumSize(self.size())
         # Open with room for the capture preview; the user can still shrink to the minimum
         self.resize(self.width(), max(self.height(), 680))
-        self._refresh_windows()
+        self._refresh_sources()
         self._load_models()
 
     def _create_worker(self) -> ProcessWorker:
@@ -367,57 +375,35 @@ class MainWindow(QMainWindow):
             self._pair_hint.setText(f"{source} \u2192 {target}: the selected engines handle this pair.")
 
     def _build_capture_group(self) -> QGroupBox:
-        """Window selection, capture controls and the preview."""
+        """Source selection, capture controls and the preview."""
         # ==================== CAPTURE ====================
-        # Window selection + Preview in one logical group
+        # Source selection + Preview in one logical group
         capture_group = QGroupBox("Capture")
         capture_layout = QVBoxLayout(capture_group)
 
-        # Window selection row
-        window_row = QHBoxLayout()
+        # Source row: windows (or the Wayland portal picker) and video devices in one list
+        source_row = QHBoxLayout()
 
-        # Configure OCR button (shared by both Wayland and X11)
+        self._window_combo = QComboBox()
+        self._window_combo.setMinimumWidth(250)
+        source_row.addWidget(self._window_combo, 1)
+
+        self._start_btn = QPushButton("Start Capture")
+        self._start_btn.setProperty("primary", True)
+        self._start_btn.setEnabled(False)  # Disabled until models are loaded
+        self._start_btn.clicked.connect(self._toggle_capture)
+        source_row.addWidget(self._start_btn)
+
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self._refresh_sources)
+        source_row.addWidget(refresh_btn)
+
         self._ocr_config_btn = QPushButton("Configure OCR")
         self._ocr_config_btn.setEnabled(False)  # Disabled until capturing
         self._ocr_config_btn.clicked.connect(self._open_ocr_config)
+        source_row.addWidget(self._ocr_config_btn)
 
-        if self._is_wayland_session:
-            # Wayland: single toggle button for capture
-            self._select_window_btn = QPushButton("Start Capture")
-            self._select_window_btn.setProperty("primary", True)
-            self._select_window_btn.setEnabled(False)  # Disabled until models are loaded
-            self._select_window_btn.clicked.connect(self._toggle_wayland_capture)
-            window_row.addWidget(self._select_window_btn, 1)
-            window_row.addWidget(self._ocr_config_btn)
-
-            # Not used in Wayland mode
-            self._window_combo = None
-            self._start_btn = None
-            self._stop_btn = None
-        else:
-            # X11/macOS/Windows: dropdown + start/refresh buttons
-            self._window_combo = QComboBox()
-            self._window_combo.setMinimumWidth(250)
-            self._window_combo.activated.connect(self._on_window_selected)
-            window_row.addWidget(self._window_combo, 1)
-
-            self._start_btn = QPushButton("Start Capture")
-            self._start_btn.setProperty("primary", True)
-            self._start_btn.setEnabled(False)  # Disabled until models are loaded
-            self._start_btn.clicked.connect(self._toggle_capture)
-            window_row.addWidget(self._start_btn)
-
-            refresh_btn = QPushButton("Refresh")
-            refresh_btn.clicked.connect(self._refresh_windows)
-            window_row.addWidget(refresh_btn)
-
-            window_row.addWidget(self._ocr_config_btn)
-
-            # Not used in X11 mode
-            self._select_window_btn = None
-            self._stop_btn = None
-
-        capture_layout.addLayout(window_row)
+        capture_layout.addLayout(source_row)
 
         # Preview (centered, aspect ratio preserved)
         self._preview_label = QLabel()
@@ -1144,21 +1130,13 @@ class MainWindow(QMainWindow):
 
     def _on_models_ready(self):
         """Handle models loaded signal from worker thread."""
-        # Enable the appropriate capture button
-        if self._start_btn:
-            self._start_btn.setEnabled(True)
-        if self._select_window_btn:
-            self._select_window_btn.setEnabled(True)
+        self._start_btn.setEnabled(True)
         self.statusBar().showMessage("Ready")
         logger.debug("models loaded")
 
     def _on_models_failed(self, error: str):
         """Handle model loading failure from worker thread."""
-        # Disable the appropriate capture button
-        if self._start_btn:
-            self._start_btn.setEnabled(False)
-        if self._select_window_btn:
-            self._select_window_btn.setEnabled(False)
+        self._start_btn.setEnabled(False)
         self._show_fix_models_button()
         self.statusBar().showMessage(f"Model loading failed: {error[:120]}")
         # Full message on hover, since the status bar truncates
@@ -1272,31 +1250,53 @@ class MainWindow(QMainWindow):
         self._process_worker.set_mode(self._mode)
         self._process_worker.start(self._config.ocr_confidence)
 
-    def _refresh_windows(self):
-        """Refresh the window list (X11 only)."""
-        if self._is_wayland_session or self._window_combo is None:
-            return
+    def _refresh_sources(self):
+        """Refresh the source list: windows (or the Wayland picker) followed by video devices.
 
+        Each item carries a (kind, value) tuple: ("portal", None), ("window", index into
+        self._windows_list) or ("device", device name).
+        """
         self._window_combo.clear()
-        self._windows_list = WindowCapture.list_windows()
         selected_idx = -1
 
-        for i, win in enumerate(self._windows_list):
-            title = win.get("title", "Unknown")
-            bounds = win.get("bounds", {})
-            width = bounds.get("width", 0)
-            height = bounds.get("height", 0)
-            if len(title) > 50:
-                title = title[:50] + "..."
-            display_text = f"{title} ({width}x{height})"
-            self._window_combo.addItem(display_text)
+        if self._is_wayland_session:
+            # Wayland has no window list; the portal shows the system picker on start
+            self._windows_list = []
+            self._window_combo.addItem("Window (system picker)", ("portal", None))
+            selected_idx = 0
+        else:
+            self._windows_list = WindowCapture.list_windows()
+            for i, win in enumerate(self._windows_list):
+                title = win.get("title", "Unknown")
+                bounds = win.get("bounds", {})
+                width = bounds.get("width", 0)
+                height = bounds.get("height", 0)
+                if len(title) > 50:
+                    title = title[:50] + "..."
+                self._window_combo.addItem(f"{title} ({width}x{height})", ("window", i))
 
-            # Auto-select if matches config
-            if self._config.window_title and self._config.window_title.lower() in win.get("title", "").lower():
-                selected_idx = i
+                # Auto-select if matches config
+                if self._config.window_title and self._config.window_title.lower() in win.get("title", "").lower():
+                    selected_idx = self._window_combo.count() - 1
+
+        devices = list_video_devices()
+        if devices:
+            if self._window_combo.count():
+                self._window_combo.insertSeparator(self._window_combo.count())
+            for device in devices:
+                name = device.description()
+                self._window_combo.addItem(f"Video device: {name}", ("device", name))
+                # A video device captured last wins over the window title match
+                if self._config.video_device and self._config.video_device == name:
+                    selected_idx = self._window_combo.count() - 1
 
         if selected_idx >= 0:
             self._window_combo.setCurrentIndex(selected_idx)
+
+    def _on_video_devices_changed(self):
+        """A video device was plugged in or removed; re-list unless a capture is running."""
+        if not self._capturing:
+            self._refresh_sources()
 
     def _toggle_capture(self):
         """Start or stop capture."""
@@ -1306,19 +1306,19 @@ class MainWindow(QMainWindow):
             self._start_capture()
 
     def _start_capture(self):
-        """Start capturing the selected window."""
-        # Wayland session: always use portal capture
-        if self._is_wayland_session:
+        """Start capturing the selected source."""
+        kind, value = self._window_combo.currentData() or (None, None)
+        if kind == "portal":
             self._start_wayland_capture()
             return
-
-        # X11 session: use selected window from list
-        idx = self._window_combo.currentIndex()
-        if idx < 0 or idx >= len(self._windows_list):
-            self.statusBar().showMessage("No window selected")
+        if kind == "device":
+            self._start_video_capture(value)
+            return
+        if kind != "window" or value >= len(self._windows_list):
+            self.statusBar().showMessage("No source selected")
             return
 
-        window = self._windows_list[idx]
+        window = self._windows_list[value]
         title = window.get("title", "")
         window_id = window.get("id")
         bounds = window.get("bounds")
@@ -1349,8 +1349,7 @@ class MainWindow(QMainWindow):
 
         self._last_ocr_results = []  # boxes from a previous session must not outlive it
         self._paused = False
-        if self._start_btn:
-            self._start_btn.setText("Stop Capture")
+        self._start_btn.setText("Stop Capture")
         self._pause_btn.setEnabled(True)
         self._pause_btn.setText("Hide")
         self._ocr_config_btn.setEnabled(True)
@@ -1358,6 +1357,7 @@ class MainWindow(QMainWindow):
 
         # Update config with selected window
         self._config.window_title = title
+        self._config.video_device = ""
         self._current_window_title = title  # Store for exclusion zone lookup
 
         # Set per-window OCR confidence
@@ -1367,17 +1367,67 @@ class MainWindow(QMainWindow):
         # Show overlay
         self._show_overlay()
 
-    def _on_window_selected(self, index: int):
-        """Handle window selection change (X11 only)."""
-        # Not used in Wayland mode
-        pass
+    def _start_video_capture(self, name: str):
+        """Start capturing a video device (capture card, webcam) by name."""
+        device = find_video_device(name)
+        if device is None:
+            self.statusBar().showMessage(f"Video device not found: {name[:40]}")
+            self._refresh_sources()
+            return
 
-    def _toggle_wayland_capture(self):
-        """Toggle Wayland capture on/off."""
-        if self._capturing:
-            self._stop_capture()
+        try:
+            self._capture = VideoDeviceCapture(device, self)
+            self._capture.start()
+        except Exception as e:
+            logger.error("video device capture failed", device=name, error=str(e))
+            first_line = (str(e).splitlines() or [""])[0]
+            self.statusBar().showMessage(f"Capture failed: {first_line[:100]}")
+            self._capture = None
+            return
+
+        self._process_timer.setInterval(PROCESS_INTERVAL_MS)
+        self._process_timer.start()
+
+        self._capturing = True
+
+        self._last_ocr_results = []  # boxes from a previous session must not outlive it
+        self._paused = False
+        self._start_btn.setText("Stop Capture")
+        self._pause_btn.setEnabled(True)
+        self._pause_btn.setText("Hide")
+        self._ocr_config_btn.setEnabled(True)
+        self.statusBar().showMessage(f"Capturing video device '{name[:40]}'")
+
+        # Remember the device; exclusion zones and OCR confidence are keyed by its name
+        self._config.video_device = name
+        self._current_window_title = name
+        self._process_worker.set_confidence_threshold(self._config.get_ocr_confidence(name))
+
+        # Nothing on screen to draw over: banner mode for the whole session
+        self._set_banner_only(True)
+        self._show_overlay()
+
+    def _set_banner_only(self, banner_only: bool):
+        """Lock the overlay to banner mode (video device sessions) or lift the lock again.
+
+        The user's chosen mode is restored when the lock is lifted and is never written to
+        the config by the forced switch.
+        """
+        if banner_only:
+            self._inplace_btn.setEnabled(False)
+            self._inplace_btn.setToolTip("Video devices have no window on screen to draw over: banner mode only")
+            if self._mode == OverlayMode.INPLACE:
+                self._mode_before_video = self._mode
+                self._banner_btn.setChecked(True)
+                self._apply_mode(OverlayMode.BANNER, persist=False)
         else:
-            self._start_wayland_capture()
+            self._inplace_btn.setEnabled(True)
+            self._inplace_btn.setToolTip("")
+            if self._mode_before_video is not None:
+                restored, self._mode_before_video = self._mode_before_video, None
+                self._inplace_btn.setChecked(restored == OverlayMode.INPLACE)
+                self._banner_btn.setChecked(restored == OverlayMode.BANNER)
+                self._apply_mode(restored, persist=False)
 
     def _start_wayland_capture(self):
         """Start Wayland capture using xdg-desktop-portal."""
@@ -1389,8 +1439,7 @@ class MainWindow(QMainWindow):
         self._wayland_selecting = True
 
         self.statusBar().showMessage("Select a window...")
-        if self._select_window_btn:
-            self._select_window_btn.setEnabled(False)
+        self._start_btn.setEnabled(False)
 
         try:
             self._wayland_portal = WaylandPortalCapture()
@@ -1401,8 +1450,7 @@ class MainWindow(QMainWindow):
 
             if not stream_info:
                 self.statusBar().showMessage("Window selection cancelled")
-                if self._select_window_btn:
-                    self._select_window_btn.setEnabled(True)
+                self._start_btn.setEnabled(True)
                 self._wayland_portal.close()
                 self._wayland_portal = None
                 return
@@ -1427,12 +1475,12 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage("Capturing Wayland window...")
 
             # Update button to show stop action
-            if self._select_window_btn:
-                self._select_window_btn.setText("Stop Capture")
-                self._select_window_btn.setEnabled(True)
+            self._start_btn.setText("Stop Capture")
+            self._start_btn.setEnabled(True)
 
             # Store window title for exclusion zone lookup (Wayland doesn't have window titles)
             self._current_window_title = "Wayland Capture"
+            self._config.video_device = ""
 
             # Set per-window OCR confidence
             confidence = self._config.get_ocr_confidence(self._current_window_title)
@@ -1444,8 +1492,7 @@ class MainWindow(QMainWindow):
         except Exception as e:
             logger.error("failed to start wayland capture", error=str(e))
             self.statusBar().showMessage("Wayland capture failed")
-            if self._select_window_btn:
-                self._select_window_btn.setEnabled(True)
+            self._start_btn.setEnabled(True)
             self._wayland_selecting = False
             if self._wayland_portal:
                 self._wayland_portal.close()
@@ -1473,14 +1520,8 @@ class MainWindow(QMainWindow):
         self._ocr_config_btn.setEnabled(False)
         self.statusBar().showMessage("Ready")
 
-        # Update UI based on session type
-        if self._is_wayland_session:
-            if self._select_window_btn:
-                self._select_window_btn.setText("Start Capture")
-                self._select_window_btn.setEnabled(True)
-        else:
-            if self._start_btn:
-                self._start_btn.setText("Start Capture")
+        self._start_btn.setText("Start Capture")
+        self._start_btn.setEnabled(True)
 
         # Clear preview
         self._preview_pixmap = None
@@ -1491,6 +1532,9 @@ class MainWindow(QMainWindow):
         self._banner_overlay.hide()
         self._inplace_overlay.clear_regions()
         self._inplace_overlay.hide()
+
+        # Give the inplace mode back after a video device session
+        self._set_banner_only(False)
 
     def _toggle_pause(self):
         """Toggle pause state."""
@@ -1508,6 +1552,8 @@ class MainWindow(QMainWindow):
 
     def _toggle_mode(self):
         """Toggle between banner and inplace mode via hotkey."""
+        if not self._inplace_btn.isEnabled():
+            return  # video device session: banner only
         new_mode_id = 0 if self._mode == OverlayMode.INPLACE else 1
         [self._banner_btn, self._inplace_btn][new_mode_id].setChecked(True)
         self._on_mode_changed(new_mode_id)
@@ -1616,10 +1662,15 @@ class MainWindow(QMainWindow):
 
     def _on_mode_changed(self, button_id: int):
         """Handle mode selection change."""
-        self._mode = OverlayMode.BANNER if button_id == 0 else OverlayMode.INPLACE
+        self._apply_mode(OverlayMode.BANNER if button_id == 0 else OverlayMode.INPLACE, persist=True)
+
+    def _apply_mode(self, mode: OverlayMode, persist: bool):
+        """Switch the overlay mode; persist=False for the temporary switch of a video device session."""
+        self._mode = mode
 
         self._process_worker.set_mode(self._mode)
-        self._config.overlay_mode = self._mode
+        if persist:
+            self._config.overlay_mode = self._mode
 
         if self._capturing and not self._paused:
             self._show_overlay()
@@ -1654,10 +1705,13 @@ class MainWindow(QMainWindow):
         # Get frame using unified capture interface
         frame = self._capture.get_frame()
 
-        # Check if window was closed
+        # Check if the window was closed or the video device went away
         if self._capture.window_invalid:
-            logger.info("window closed, stopping capture")
+            error = getattr(self._capture, "error", None)
+            logger.info("capture source gone, stopping capture", error=error)
             self._stop_capture()
+            if error:
+                self.statusBar().showMessage(f"Video device stopped: {error[:100]}")
             return
 
         # Get bounds (None on Wayland, dict on X11/Windows/macOS)

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -240,3 +240,121 @@ def test_stale_model_lists_are_ignored(qapp):
     assert [win._llm_model_combo.itemText(i) for i in range(win._llm_model_combo.count())] == ["a", "m"]
     assert win._llm_model_combo.currentText() == "m"
     assert win._llm_result_label.toolTip() == "2 model(s) found"
+
+
+# ---- Source list (windows + video devices) ----
+
+
+class _Device:
+    def __init__(self, name: str, id_text: str):
+        self._name, self._id = name, id_text.encode()
+
+    def description(self) -> str:
+        return self._name
+
+    def id(self) -> bytes:
+        return self._id
+
+
+def _source_window(config: Config, monkeypatch, windows: list[dict], devices: list[_Device]) -> MainWindow:
+    """A MainWindow with only the source combo, skipping __init__.
+
+    QComboBox hands item data back as lists (QVariant), so expectations below use lists.
+    """
+    import interpreter.gui.main_window as module
+
+    monkeypatch.setattr(module, "list_video_devices", lambda: list(devices))
+    # Fresh copies: the window stores the list it gets, and the tests mutate the originals
+    monkeypatch.setattr(module.WindowCapture, "list_windows", staticmethod(lambda: list(windows)))
+    win = MainWindow.__new__(MainWindow)
+    win._config = config
+    win._is_wayland_session = False
+    win._windows_list = []
+    win._window_combo = QComboBox()
+    return win
+
+
+WINDOWS = [
+    {"title": "Snes9x", "id": 11, "bounds": {"width": 800, "height": 600}},
+    {"title": "Notepad", "id": 12, "bounds": {"width": 400, "height": 300}},
+]
+
+
+def test_refresh_sources_selects_saved_device_by_id_over_name(qapp, monkeypatch):
+    """Greptile: two cards with the same description must be told apart by id."""
+    config = Config(window_title="Snes9x", video_device="USB Video", video_device_id="usb#2")
+    devices = [_Device("USB Video", "usb#1"), _Device("USB Video", "usb#2")]
+    win = _source_window(config, monkeypatch, WINDOWS, devices)
+    win._refresh_sources()
+    assert win._window_combo.currentData() == ["device", ["usb#2", "USB Video"]]
+    assert win._window_combo.currentText() == "Video device: USB Video (2)"
+
+
+def test_refresh_sources_falls_back_to_device_name_when_id_is_gone(qapp, monkeypatch):
+    config = Config(window_title="Snes9x", video_device="USB Video", video_device_id="usb#old")
+    win = _source_window(config, monkeypatch, WINDOWS, [_Device("USB Video", "usb#new")])
+    win._refresh_sources()
+    assert win._window_combo.currentData() == ["device", ["usb#new", "USB Video"]]
+
+
+def test_refresh_sources_keeps_the_users_unstarted_selection(qapp, monkeypatch):
+    """Greptile: a hot-plug refresh must not replace a source the user picked but has not started."""
+    config = Config(window_title="Snes9x", video_device="Capture A", video_device_id="a")
+    devices = [_Device("Capture A", "a"), _Device("Capture B", "b")]
+    win = _source_window(config, monkeypatch, devices=devices, windows=WINDOWS)
+    win._refresh_sources()
+    assert win._window_combo.currentData() == ["device", ["a", "Capture A"]]
+
+    # The user picks Capture B, then a webcam is plugged in
+    combo = win._window_combo
+    combo.setCurrentIndex(combo.findData(["device", ["b", "Capture B"]]))
+    devices.append(_Device("Webcam", "w"))
+    win._refresh_sources()
+    assert combo.currentData() == ["device", ["b", "Capture B"]]
+
+    # Same for a window pick, whose list index may shift
+    combo.setCurrentIndex(combo.findData(["window", 1]))
+    WINDOWS.insert(0, {"title": "New window", "id": 10, "bounds": {"width": 1, "height": 1}})
+    try:
+        win._refresh_sources()
+        assert combo.currentText().startswith("Notepad")
+    finally:
+        WINDOWS.pop(0)
+
+    # A selection that disappeared falls back to the config
+    combo.setCurrentIndex(combo.findData(["device", ["w", "Webcam"]]))
+    devices.pop()
+    win._refresh_sources()
+    assert combo.currentData() == ["device", ["a", "Capture A"]]
+
+
+def test_banner_click_during_video_session_is_not_persisted(qapp):
+    """Greptile: clicking the (already checked) Banner button while locked must not save Banner."""
+    from PySide6.QtWidgets import QPushButton
+
+    from interpreter.config import OverlayMode
+
+    config = Config(overlay_mode=OverlayMode.INPLACE)
+    win = MainWindow.__new__(MainWindow)
+    win._config = config
+    win._mode = OverlayMode.INPLACE
+    win._capturing = False
+    win._paused = False
+    win._banner_only = False
+    win._mode_before_video = None
+    win._banner_btn, win._inplace_btn = QPushButton(), QPushButton()
+    for btn in (win._banner_btn, win._inplace_btn):
+        btn.setCheckable(True)
+    win._inplace_btn.setChecked(True)
+    calls = []
+    win._process_worker = type("W", (), {"set_mode": lambda self, m: calls.append(m)})()
+
+    win._set_banner_only(True)
+    assert win._mode == OverlayMode.BANNER and config.overlay_mode == OverlayMode.INPLACE
+    win._on_mode_changed(0)  # user clicks Banner during the session
+    assert config.overlay_mode == OverlayMode.INPLACE
+    win._set_banner_only(False)
+    assert win._mode == OverlayMode.INPLACE and win._inplace_btn.isChecked()
+    assert config.overlay_mode == OverlayMode.INPLACE
+    win._on_mode_changed(0)  # a real choice after the session is saved
+    assert config.overlay_mode == OverlayMode.BANNER

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -358,3 +358,100 @@ def test_banner_click_during_video_session_is_not_persisted(qapp):
     assert config.overlay_mode == OverlayMode.INPLACE
     win._on_mode_changed(0)  # a real choice after the session is saved
     assert config.overlay_mode == OverlayMode.BANNER
+
+
+def test_no_signal_state_is_reset_when_capture_stops(qapp, monkeypatch):
+    """Greptile: a window capture after a stopped, signal-less video session must not touch .name."""
+    import numpy as np
+    from PySide6.QtCore import QTimer
+    from PySide6.QtWidgets import QLabel, QMainWindow, QPushButton
+
+    import interpreter.gui.main_window as module
+    from interpreter.config import OverlayMode
+
+    class NoSignalVideo:
+        """A video device that never delivers a frame."""
+
+        name = "Silent card"
+        bounds = None
+        window_invalid = False
+
+        def get_frame(self):
+            return None
+
+        def stop(self):
+            pass
+
+    class WindowLike:
+        """The shape of WindowCapture the frame loop relies on, without a .name attribute."""
+
+        bounds = {"x": 0, "y": 0, "width": 4, "height": 2}
+        window_invalid = False
+
+        def get_frame(self):
+            f = np.zeros((2, 4, 4), np.uint8)
+            f[..., 3] = 255
+            return f
+
+        def stop(self):
+            pass
+
+    class Overlay:
+        def hide(self):
+            pass
+
+        def clear_regions(self):
+            pass
+
+        def ensure_above(self, window_id):
+            pass
+
+    # The frame loop tells video sources apart with isinstance
+    monkeypatch.setattr(module, "VideoDeviceCapture", NoSignalVideo)
+
+    win = MainWindow.__new__(MainWindow)
+    QMainWindow.__init__(win)
+    win._config = Config(overlay_mode=OverlayMode.BANNER)
+    win._mode = OverlayMode.BANNER
+    win._paused = True  # keep the loop away from the preview, overlays and the worker
+    win._capturing = True
+    win._frames_missing = 0
+    win._waiting_for_signal = False
+    win._last_ocr_results = []
+    win._last_frame = None
+    win._process_timer = QTimer()
+    win._wayland_portal = None
+    win._pause_btn = QPushButton()
+    win._ocr_config_btn = QPushButton()
+    win._start_btn = QPushButton()
+    win._preview_label = QLabel()
+    win._preview_pixmap = None
+    win._banner_only = False
+    win._mode_before_video = None
+    win._inplace_btn = QPushButton()
+    win._banner_btn = QPushButton()
+    win._banner_overlay = win._inplace_overlay = Overlay()
+    win._current_window_title = ""
+    win._ocr_config_dialog = None
+    win._last_bounds = {}
+    win._process_worker = type("W", (), {"submit_frame": lambda self, f: None})()
+
+    win._capture = NoSignalVideo()
+    for _ in range(8):  # 4 s of ticks without a frame
+        win._capture_and_process()
+    assert win._waiting_for_signal
+    assert "Waiting for a video signal" in win.statusBar().currentMessage()
+
+    win._stop_capture()
+    assert not win._waiting_for_signal and win._frames_missing == 0
+
+    # A window capture must get past the no-signal block on its first frame
+    win._capture = WindowLike()
+    win._capturing = True
+    win._paused = True
+    monkeypatch.setattr(win, "_last_frame", None)
+    try:
+        win._capture_and_process()
+    except AttributeError as e:  # the exact failure Greptile described
+        pytest.fail(str(e))
+    assert win._last_frame is not None

--- a/tests/test_video_device.py
+++ b/tests/test_video_device.py
@@ -154,3 +154,39 @@ def test_live_capture_from_attached_device(qapp):
     finally:
         capture.stop()
         qapp.processEvents()
+
+
+class FakeDevice:
+    def __init__(self, name: str, id_text: str):
+        self._name = name
+        self._id = id_text.encode()
+
+    def description(self) -> str:
+        return self._name
+
+    def id(self) -> bytes:
+        return self._id
+
+
+def test_find_video_device_matches_id_before_name(monkeypatch):
+    """Greptile: two cards of the same model share a description; the id tells them apart."""
+    import interpreter.capture.video_device as module
+
+    first, second = FakeDevice("USB Video", "usb#1"), FakeDevice("USB Video", "usb#2")
+    monkeypatch.setattr(module, "list_video_devices", lambda: [first, second])
+    assert find_video_device("USB Video", "usb#2") is second
+    assert find_video_device("USB Video", "usb#1") is first
+    # Unknown id (Linux renumbered /dev/video) falls back to the name
+    assert find_video_device("USB Video", "usb#9") is first
+    assert find_video_device("USB Video") is first
+    assert find_video_device("Other", "usb#9") is None
+
+
+def test_config_round_trips_video_device_id(tmp_path):
+    path = tmp_path / "config.yml"
+    config = Config(config_path=str(path))
+    config.video_device = "USB Video"
+    config.video_device_id = r"\?\usb#vid_1234&pid_5678"
+    config.save()
+    loaded = Config.load(str(path))
+    assert (loaded.video_device, loaded.video_device_id) == ("USB Video", r"\?\usb#vid_1234&pid_5678")

--- a/tests/test_video_device.py
+++ b/tests/test_video_device.py
@@ -124,3 +124,33 @@ def test_config_omits_empty_video_device(tmp_path):
     Config(config_path=str(path)).save()
     assert "video_device" not in path.read_text(encoding="utf-8")
     assert Config.load(str(path)).video_device == ""
+
+
+def test_live_capture_from_attached_device(qapp):
+    """Live check, skipped unless a video device (capture card, webcam) is attached.
+
+    Run it with a device plugged in: uv run pytest tests/test_video_device.py -k live -s
+    """
+    from PySide6.QtCore import QDeadlineTimer
+
+    from interpreter.capture.video_device import list_video_devices
+
+    devices = list_video_devices()
+    if not devices:
+        pytest.skip("no video device attached")
+
+    capture = VideoDeviceCapture(devices[0])
+    capture.start()
+    try:
+        frame = None
+        deadline = QDeadlineTimer(8000)
+        while frame is None and not deadline.hasExpired() and not capture.window_invalid:
+            qapp.processEvents()
+            frame = capture.get_frame()
+        assert capture.error is None, capture.error
+        assert frame is not None, "no frame within 8 s"
+        assert frame.ndim == 3 and frame.shape[2] == 4 and frame.dtype == np.uint8
+        print(f"\n{capture.name}: {frame.shape[1]}x{frame.shape[0]}, mean brightness {frame[..., :3].mean():.1f}")
+    finally:
+        capture.stop()
+        qapp.processEvents()

--- a/tests/test_video_device.py
+++ b/tests/test_video_device.py
@@ -1,0 +1,126 @@
+"""Tests for the video device capture source (format choice, frame conversion, config)."""
+
+import numpy as np
+import pytest
+from PySide6.QtCore import QSize
+from PySide6.QtGui import QColor, QImage
+from PySide6.QtMultimedia import QVideoFrameFormat
+from PySide6.QtWidgets import QApplication
+
+from interpreter.capture.video_device import (
+    MAX_FRAME_AREA,
+    VideoDeviceCapture,
+    choose_format,
+    find_video_device,
+    qimage_to_bgra,
+)
+from interpreter.config import Config
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return QApplication.instance() or QApplication([])
+
+
+class FakeFormat:
+    """Stand-in for QCameraFormat (its constructor is not public)."""
+
+    def __init__(self, width: int, height: int, fps: float, pixel_format=QVideoFrameFormat.PixelFormat.Format_NV12):
+        self._size = QSize(width, height)
+        self._fps = fps
+        self._pixel_format = pixel_format
+
+    def resolution(self) -> QSize:
+        return self._size
+
+    def maxFrameRate(self) -> float:
+        return self._fps
+
+    def pixelFormat(self):
+        return self._pixel_format
+
+
+MJPEG = QVideoFrameFormat.PixelFormat.Format_Jpeg
+
+
+def test_choose_format_prefers_largest_resolution_up_to_1080p():
+    formats = [
+        FakeFormat(640, 480, 30),
+        FakeFormat(3840, 2160, 60),
+        FakeFormat(1920, 1080, 60),
+        FakeFormat(1280, 720, 60),
+    ]
+    chosen = choose_format(formats)
+    assert chosen.resolution() == QSize(1920, 1080)
+    assert chosen.resolution().width() * chosen.resolution().height() <= MAX_FRAME_AREA
+
+
+def test_choose_format_prefers_uncompressed_over_mjpeg_at_usable_fps():
+    formats = [FakeFormat(1920, 1080, 60, MJPEG), FakeFormat(1920, 1080, 30)]
+    assert choose_format(formats).pixelFormat() != MJPEG
+
+
+def test_choose_format_skips_crawling_uncompressed_modes():
+    """USB 2 cards expose 1080p YUY2 at 5 fps; MJPEG at 60 fps is the better mode."""
+    formats = [FakeFormat(1920, 1080, 5, QVideoFrameFormat.PixelFormat.Format_YUYV), FakeFormat(1920, 1080, 60, MJPEG)]
+    assert choose_format(formats).pixelFormat() == MJPEG
+
+
+def test_choose_format_takes_the_higher_frame_rate_otherwise():
+    formats = [FakeFormat(1920, 1080, 30), FakeFormat(1920, 1080, 60)]
+    assert choose_format(formats).maxFrameRate() == 60
+
+
+def test_choose_format_falls_back_to_smallest_oversized_mode():
+    formats = [FakeFormat(3840, 2160, 30), FakeFormat(2560, 1440, 60)]
+    assert choose_format(formats).resolution() == QSize(2560, 1440)
+
+
+def test_choose_format_handles_no_formats():
+    assert choose_format([]) is None
+
+
+def test_qimage_to_bgra_returns_bgra_and_copies(qapp):
+    image = QImage(5, 3, QImage.Format.Format_RGB32)
+    image.fill(QColor(10, 20, 30))
+    frame = qimage_to_bgra(image)
+    assert frame.shape == (3, 5, 4)
+    assert frame.dtype == np.uint8
+    assert tuple(frame[0, 0]) == (30, 20, 10, 255)
+    # The array must outlive the QImage
+    del image
+    assert tuple(frame[2, 4]) == (30, 20, 10, 255)
+
+
+def test_qimage_to_bgra_handles_padded_rows(qapp):
+    """Qt pads scanlines to 4 bytes; RGB888 with an odd width has a stride wider than width*3."""
+    image = QImage(3, 2, QImage.Format.Format_RGB888)
+    image.fill(QColor(1, 2, 3))
+    frame = qimage_to_bgra(image)
+    assert frame.shape == (2, 3, 4)
+    assert tuple(frame[1, 2]) == (3, 2, 1, 255)
+
+
+def test_find_video_device_unknown_name(qapp):
+    assert find_video_device("no such capture card") is None
+
+
+def test_video_device_capture_conforms_to_capture_protocol():
+    """Static check: everything the GUI's frame loop calls on a capture source."""
+    for attr in ("get_frame", "bounds", "window_invalid", "get_content_offset", "stop", "start"):
+        assert hasattr(VideoDeviceCapture, attr)
+
+
+def test_config_round_trips_video_device(tmp_path):
+    path = tmp_path / "config.yml"
+    config = Config(config_path=str(path))
+    config.video_device = "Game Capture HD60 X"
+    config.save()
+    assert Config.load(str(path)).video_device == "Game Capture HD60 X"
+
+
+def test_config_omits_empty_video_device(tmp_path):
+    path = tmp_path / "config.yml"
+    Config(config_path=str(path)).save()
+    assert "video_device" not in path.read_text(encoding="utf-8")
+    assert Config.load(str(path)).video_device == ""


### PR DESCRIPTION
Closes #247

## What

Adds a video device capture source so a console game can be translated straight from a capture card instead of through an OBS window. The console plays on the TV through the card's passthrough; the banner with the translation floats on the PC screen.

- **New source** `capture/video_device.py`: `VideoDeviceCapture` implements the existing `Capture` protocol on top of `QCamera` / `QMediaCaptureSession` / `QVideoSink`. Frames are converted to BGRA on demand at the processing cadence, so the card's own frame rate costs nothing extra. Qt Multimedia already ships with the PySide6 wheels (FFmpeg backend on Windows, macOS and Linux), so there is no new dependency.
- **Mode selection**: largest resolution up to 1080p, an uncompressed mode at a usable frame rate over MJPEG, then the higher frame rate. Avoids the 640x480 default and the 5 fps 1080p YUY2 modes of USB 2 cards.
- **One source list** on all platforms: windows (or the Wayland system picker) followed by "Video device: name" entries. The list refreshes on hot-plug. The old Wayland-only button and `_refresh_windows` are folded into the same start button and `_refresh_sources`.
- **Banner mode only** while a video device is captured: there is no window on screen to anchor the inplace overlay. The Inplace button is disabled with a tooltip, the mode hotkey is ignored, and the user's mode is restored on stop without touching the config.
- **Unplugging** the device stops the capture and shows the reason in the status bar.
- **Config**: new `video_device` key remembers the last device (empty when a window was captured last). Exclusion zones and OCR confidence are keyed by the device name, like they are by window title.
- README section on the capture card setup.

## Testing

- 267 tests pass, 13 new (format choice, QImage to BGRA conversion, config round trip, protocol conformance, and a live test that skips without hardware).
- Verified live on Windows 11 with an Apple Studio Display camera, a UVC device like a capture card: listed by name, 1920x1080 NV12 at 30 fps chosen, first frame in 0.7 s, 5 ms per frame conversion. Full app flow checked: auto-select from config, forced banner mode, preview, banner on the desktop, mode restored on stop, clean camera release.
- Not verified: a real capture card, macOS (the camera permission prompt is left to Qt's backend and attributed to the terminal since the app runs as a bare Python), and the Wayland layout change (the portal flow itself is unchanged).

## Known limitation

Qt 6 enumerates Windows cameras through Media Foundation only, so DirectShow-only software cameras (OBS Virtual Camera, Snap Camera, NDI Webcam Input) do not appear. Real capture cards are UVC or AVStream devices and do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
